### PR TITLE
Avoid duplicate CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches: [master]
 jobs:
   test: # from https://github.com/simeonschaub/OptionalArgChecks.jl/blob/457488ef04ed68a37aff10af1cb3909f47a8230c/.github/workflows/ci.yml#L23-L37
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}


### PR DESCRIPTION
## Summary
- Scopes `push` trigger to `master` branch only, so PRs only run CI once (via the `pull_request` event) instead of twice

Previously the bare `on: [push, pull_request]` caused every PR push to trigger two identical workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)