### PR TITLE
Fix ParYield for sub-period maturities

### DIFF
--- a/src/Contract.jl
+++ b/src/Contract.jl
@@ -185,7 +185,8 @@ module Bond
         coupon_period = 1 / frequency.frequency
         if maturity ≤ coupon_period
             # No coupon date before maturity → zero-coupon instrument
-            return Quote(discount(yield, maturity), Cashflow(1.0, maturity))
+            # Interpret yield in the context of the specified frequency
+            return Quote(discount(frequency(yield), maturity), Cashflow(1.0, maturity))
         else
             price = 1.0 # by definition for a par bond
             coupon_rate = rate(frequency(yield))

--- a/test/Yield.jl
+++ b/test/Yield.jl
@@ -125,6 +125,11 @@ end
         q_1y = ParYield(Periodic(r, 2), 1)
         @test q_1y.instrument isa FinanceModels.Bond.Fixed
         @test q_1y.price == 1.0
+
+        # Plain number and Rate methods should produce the same quote
+        q_num = ParYield(r, 1 // 4)                # plain Float64, default Periodic(2)
+        q_rate = ParYield(Periodic(r, 2), 1 // 4)  # explicit Rate
+        @test q_num.price ≈ q_rate.price
     end
 
     @testset "simple rate and forward" begin


### PR DESCRIPTION
## Summary

- **Fix**: `ParYield` now treats maturities ≤ one coupon period (`1/frequency`) as zero-coupon instruments instead of incorrectly generating a coupon-bearing bond
- **Fix**: Plain-number `ParYield(0.04, 1//4)` now interprets the yield in the specified `frequency` convention, consistent with the `Rate` method and the coupon-bearing branch
- **Docs**: Updated `ParYield` docstring to accurately describe behavior
- **Test**: Adds tests verifying both fixes

## Problem 1: Coupon paid before first coupon date

When `maturity ≤ 1/frequency` (e.g. a 3-month instrument with semi-annual coupons), `ParYield` was creating a `Bond.Fixed` with a full coupon payment at maturity. Since `coupon_times` clamps `Δt = min(1/frequency, maturity)`, both a 0.25y and 0.5y par bond at the same rate would produce a single cashflow of `1 + rate/frequency` — identical amounts at different times:

```
ParYield(Periodic(0.04, 2), 1//4)  →  cashflow of 1.02 at t=0.25
ParYield(Periodic(0.04, 2), 1//2)  →  cashflow of 1.02 at t=0.50
```

Both imply `discount = 1/1.02 ≈ 0.98039`, making fitted curves degenerate at the short end (nearly identical discount factors at 3m and 6m).

A 3-month instrument should **not** pay a 6-month coupon — no coupon date occurs before maturity.

## Problem 2: Inconsistent yield interpretation for plain numbers

The plain-number method `ParYield(yield, maturity)` used `discount(yield, maturity)` in the zero-coupon branch, which interprets a `Float64` as `Periodic(1)` (annual effective). But the coupon-bearing branch interprets the same number through the `frequency` parameter via `rate(frequency(yield))`. This meant:

```julia
ParYield(0.04, 1//4)               # discount(0.04, 0.25) → 0.04 as annual effective
ParYield(Periodic(0.04, 2), 1//4)  # discount(Rate, 0.25) → 0.04 as semi-annual nominal
```

produced different quote prices for the same economic input.

## Fix

**Sub-period maturities** (`maturity ≤ 1/frequency`): `ParYield` now returns a zero-coupon quote:

```julia
Quote(discount(frequency(yield), maturity), Cashflow(1.0, maturity))
```

The yield is converted through `frequency` first (e.g. `Periodic(2)(0.04)`), ensuring consistent interpretation whether a plain number or `Rate` is passed. This matches how `CMTYield` already handles short-dated instruments.

For maturities above one coupon period, behavior is unchanged.

## Before/After

| Maturity | Before | After |
|---|---|---|
| 0.25y (semi-annual) | `Quote(1.0, Fixed(0.04, Periodic(2), 0.25))` — full coupon, price=1 | `Quote(0.9901, Cashflow(1.0, 0.25))` — zero-coupon |
| 0.50y (semi-annual) | `Quote(1.0, Fixed(0.04, Periodic(2), 0.5))` — full coupon, price=1 | `Quote(0.9804, Cashflow(1.0, 0.5))` — zero-coupon |
| 1.0y (semi-annual) | `Quote(1.0, Fixed(0.04, Periodic(2), 1))` — unchanged | `Quote(1.0, Fixed(0.04, Periodic(2), 1))` — unchanged |

## Test plan

- [x] New `"ParYield sub-period maturity"` testset verifying:
  - Sub-period quotes produce `Cashflow` (not `Bond.Fixed`)
  - Quote prices match `discount(yield, maturity)`
  - 3m and 6m discount factors are distinct (`q_3m.price > q_6m.price`)
  - Above-period maturities still produce par bonds with price = 1.0
  - Plain-number and `Rate` methods produce the same quote price
- [x] All existing tests pass (2,159 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)