### PR TITLE
Constrain yield +/- fallbacks to Union{Real,Rate}

### DIFF
--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -352,7 +352,7 @@ function Base.:+(a::Constant, b::Constant)
     return Constant(Continuous(z_a + z_b))
 end
 
-function Base.:+(a::T, b) where {T <: AbstractYieldModel}
+function Base.:+(a::T, b::Union{Real,Rate}) where {T <: AbstractYieldModel}
     return a + Constant(b)
 end
 
@@ -401,7 +401,7 @@ function Base.:-(a::Constant, b::Constant)
     return Constant(Continuous(z_a - z_b))
 end
 
-function Base.:-(a::T, b) where {T <: AbstractYieldModel}
+function Base.:-(a::T, b::Union{Real,Rate}) where {T <: AbstractYieldModel}
     return a - Constant(b)
 end
 


### PR DESCRIPTION
## Summary

Narrow the second argument of the `+(::AbstractYieldModel, b)` and `-(::AbstractYieldModel, b)` fallbacks from `::Any` to `::Union{Real, Rate}`.

## Motivation

These two methods accept any type as the second operand, but immediately pass it to `Constant(b)`, which only handles `Real` and `Rate`. The unconstrained `::Any` signature causes broad method table invalidations when FinanceModels is loaded (#221), slowing down compilation for downstream packages.

Constraining to `Union{Real, Rate}` matches the actual domain and reduces invalidation scope per SnoopCompile best practices.

## Changes

**File:** `src/model/Yield.jl`

```diff
-function Base.:+(a::T, b) where {T <: AbstractYieldModel}
+function Base.:+(a::T, b::Union{Real,Rate}) where {T <: AbstractYieldModel}

-function Base.:-(a::T, b) where {T <: AbstractYieldModel}
+function Base.:-(a::T, b::Union{Real,Rate}) where {T <: AbstractYieldModel}
```

## Test plan

- [x] Full test suite passes (2,000+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)