### PR TITLE
Rename ForwardYields to ForwardYield

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -114,7 +114,7 @@ A number of convenience functions are included to construct a `Quote`:
 - `ParYield`
 - `CMTYield`
 - `OISYield`
-- `ForwardYields`
+- `ForwardYield`
 
 ## 4. **Models** - Not just yield curves anymore
 

--- a/src/Contract.jl
+++ b/src/Contract.jl
@@ -263,19 +263,19 @@ module Bond
     end
 
     """
-        ForwardYields(yields,times) 
+        ForwardYield(yields,times)
 
-    Returns a vector of `Quote` corresponding to the yield at the given forward times. 
-        
+    Returns a vector of `Quote` corresponding to the yield at the given forward times.
+
     # Examples
     ```julia-repl
-    julia> FinanceModels.Bond.ForwardYields([0.01,0.02],[1.,3.])
+    julia> FinanceModels.Bond.ForwardYield([0.01,0.02],[1.,3.])
     2-element Vector{Quote{Float64, Cashflow{Float64, Float64}}}:
      Quote{Float64, Cashflow{Float64, Float64}}(0.9900990099009901, Cashflow{Float64, Float64}(1.0, 1.0))
      Quote{Float64, Cashflow{Float64, Float64}}(0.9423223345470445, Cashflow{Float64, Float64}(1.0, 3.0))
     ```
     """
-    function ForwardYields(yields, times = eachindex(yields))
+    function ForwardYield(yields, times = eachindex(yields))
         df = 1.0
         t_prior = 0.0
         return map(zip(yields, times)) do (y, t)
@@ -287,7 +287,6 @@ module Bond
             )
         end
     end
-
 
     # Bond utility funcs
 
@@ -323,7 +322,7 @@ module Bond
     coupon_times(b::AbstractBond) = coupon_times(b.maturity, b.frequency.frequency)
 
 
-    for op in (:ZCBPrice, :ZCBYield, :ParYield, :ParSwapYield, :CMTYield, :ForwardYield)
+    for op in (:ZCBPrice, :ZCBYield, :ParYield, :ParSwapYield, :CMTYield)
         eval(
             quote
                 $op(x::Vector; kwargs...) = $op.(x, float.(eachindex(x)); kwargs...)

--- a/src/FinanceModels.jl
+++ b/src/FinanceModels.jl
@@ -27,8 +27,8 @@ include("fit.jl")
 
 export Cashflow, Quote, Forward, CommonEquity, Option, InterestRateSwap
 
-using .Bond: ZCBYield, ZCBPrice, ParSwapYield, ParYield, CMTYield, ForwardYields, OISYield
-export Bond, ZCBYield, ZCBPrice, ParSwapYield, ParYield, CMTYield, ForwardYields, OISYield
+using .Bond: ZCBYield, ZCBPrice, ParSwapYield, ParYield, CMTYield, ForwardYield, OISYield
+export Bond, ZCBYield, ZCBPrice, ParSwapYield, ParYield, CMTYield, ForwardYield, OISYield
 
 export Spline
 

--- a/test/Yield.jl
+++ b/test/Yield.jl
@@ -179,7 +179,7 @@ end
     @testset "Forward Rates" begin
         # Risk Managment and Financial Institutions, 5th ed. Appendix B
         forwards = [0.05, 0.04, 0.03, 0.08]
-        qs = ForwardYields(forwards, [1, 2, 3, 4])
+        qs = ForwardYield(forwards, [1, 2, 3, 4])
         curve = fit(Spline.Cubic(), qs, Fit.Bootstrap())
 
 
@@ -191,8 +191,8 @@ end
 
         @testset "pv with vector discount rates" begin
             cf = [100, 100]
-            f(rates) = fit(Spline.Linear(), ForwardYields(rates), Fit.Bootstrap())
-            f(rates, times) = fit(Spline.Linear(), ForwardYields(rates, times), Fit.Bootstrap())
+            f(rates) = fit(Spline.Linear(), ForwardYield(rates), Fit.Bootstrap())
+            f(rates, times) = fit(Spline.Linear(), ForwardYield(rates, times), Fit.Bootstrap())
             @test pv(f([0.0, 0.05]), cf) ≈ 100 / 1.0 + 100 / 1.05
             @test pv(f([0.0, 0.05]), cf) ≈ 100 / 1.0 + 100 / 1.05
             @test pv(f([0.05, 0.0]), cf) ≈ 100 / 1.05 + 100 / 1.05
@@ -207,7 +207,7 @@ end
 
 
         # test constructor without times
-        qs = ForwardYields(forwards)
+        qs = ForwardYield(forwards)
 
         @testset "discounts: $t" for (t, r) in enumerate(forwards)
             @test discount(curve, t) ≈ reduce((v, r) -> v / (1 + r), forwards[1:t]; init = 1.0)
@@ -224,7 +224,7 @@ end
 
         # test construction using vector of reals and of Rates
         curve_c = let
-            qs = ForwardYields(Continuous.(forwards), [1, 2, 3, 4])
+            qs = ForwardYield(Continuous.(forwards), [1, 2, 3, 4])
             fit(Spline.Cubic(), qs, Fit.Bootstrap())
         end
         @test discount(curve, 1) > discount(curve_c, 1)
@@ -238,7 +238,7 @@ end
         @testset "with specified non integer timepoints" begin
             i = [0.0, 0.05]
             times = [0.5, 1.5]
-            qs = ForwardYields(i, times)
+            qs = ForwardYield(i, times)
             m = fit(Spline.Linear(), qs, Fit.Bootstrap())
             @test discount(m, 0.5) ≈ 1 / 1.0^0.5
             @test discount(m, 1.5) ≈ 1 / 1.0^0.5 / 1.05^1
@@ -468,7 +468,7 @@ end
     @testset "Forward Rates" begin
         # Risk Managment and Financial Institutions, 5th ed. Appendix B
         forwards = [0.05, 0.04, 0.03, 0.08]
-        qs = ForwardYields(forwards, [1, 2, 3, 4])
+        qs = ForwardYield(forwards, [1, 2, 3, 4])
         curve = fit(Spline.Cubic(), qs)
 
 
@@ -480,8 +480,8 @@ end
 
         @testset "pv with vector discount rates" begin
             cf = [100, 100]
-            f(rates) = fit(Spline.Linear(), ForwardYields(rates))
-            f(rates, times) = fit(Spline.Linear(), ForwardYields(rates, times))
+            f(rates) = fit(Spline.Linear(), ForwardYield(rates))
+            f(rates, times) = fit(Spline.Linear(), ForwardYield(rates, times))
             @test pv(f([0.0, 0.05]), cf) ≈ 100 / 1.0 + 100 / 1.05
             @test pv(f([0.0, 0.05]), cf) ≈ 100 / 1.0 + 100 / 1.05
             @test pv(f([0.05, 0.0]), cf) ≈ 100 / 1.05 + 100 / 1.05
@@ -496,7 +496,7 @@ end
 
 
         # test constructor without times
-        qs = ForwardYields(forwards)
+        qs = ForwardYield(forwards)
 
         @testset "discounts: $t" for (t, r) in enumerate(forwards)
             @test discount(curve, t) ≈ reduce((v, r) -> v / (1 + r), forwards[1:t]; init = 1.0)
@@ -513,7 +513,7 @@ end
 
         # test construction using vector of reals and of Rates
         curve_c = let
-            qs = ForwardYields(Continuous.(forwards), [1, 2, 3, 4])
+            qs = ForwardYield(Continuous.(forwards), [1, 2, 3, 4])
             fit(Spline.Cubic(), qs)
         end
         @test discount(curve, 1) > discount(curve_c, 1)
@@ -527,7 +527,7 @@ end
         @testset "with specified non integer timepoints" begin
             i = [0.0, 0.05]
             times = [0.5, 1.5]
-            qs = ForwardYields(i, times)
+            qs = ForwardYield(i, times)
             m = fit(Spline.Linear(), qs)
             @test discount(m, 0.5) ≈ 1 / 1.0^0.5
             @test discount(m, 1.5) ≈ 1 / 1.0^0.5 / 1.05^1


### PR DESCRIPTION
## Summary

Rename `ForwardYields` → `ForwardYield` (singular) and remove the dead metaprogrammed vector-convenience method.

## Motivation

Every other quote constructor in the package uses a singular name:

| Constructor | Convention |
|:------------|:-----------|
| `ZCBYield` | singular |
| `ZCBPrice` | singular |
| `ParYield` | singular |
| `ParSwapYield` | singular |
| `CMTYield` | singular |
| `OISYield` | singular |
| `ForwardYields` | **plural** |

The README and `docs/src/index.md` already referred to `ForwardYield` (singular) — the function definition was the outlier.

### Dead metaprogrammed method

The metaprogramming loop at the bottom of the `Bond` module generated a `ForwardYield(x::Vector)` convenience that broadcast a *scalar* `ForwardYield(yield, time)` — but no such scalar form exists. `ForwardYield` is inherently a batch operation: it accumulates discount factors across tenors, so it must see the full vector of forward rates at once. The generated method was dead code (would error at runtime) and has been removed from the loop.

## Changes

- `src/Contract.jl`: rename function `ForwardYields` → `ForwardYield`; remove `:ForwardYield` from metaprogramming loop
- `src/FinanceModels.jl`: update `using` and `export` to `ForwardYield`
- `test/Yield.jl`: update all call sites
- `docs/src/introduction.md`: update reference

## Breaking changes

- `ForwardYields` is no longer exported. Use `ForwardYield` instead.

## Test plan

- [x] Full test suite passes (2,000+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)