### PR TITLE
Bump version to 5.0.0, fix stale docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceModels"
 uuid = "77f2ae65-bdde-421f-ae9d-22f1af19dd76"
-version = "4.18.1"
+version = "5.0.0"
 authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![Build Status](https://github.com/JuliaActuary/FinanceModels.jl/workflows/CI/badge.svg)](https://github.com/JuliaActuary/FinanceModels.jl/actions)
 [![Coverage](https://codecov.io/gh/JuliaActuary/FinanceModels.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaActuary/FinanceModels.jl)
 
-> **NOTE**: Yields.jl has been re-written to FinanceModels.jl, but existing Yields.jl should be easy to update. See the docs for a [migration guide](https://docs.juliaactuary.org/FinanceModels/stable/migration/) for guidance on updating from the prior version. Existing, pinned/compat code should not be affected as JuliaActuary follows Semantic Versioning for its releases.
-
 **FinanceModels.jl** provides a set of composable contracts, models, and functions that allow for modeling of both simple and complex financial instruments. The resulting models, such as discount rates or term structures, can then be used across the JuliaActuary ecosystem to perform actuarial and financial analysis.
 
 Additionally, the models can be used to project contracts through time: most basically as a series of cashflows but more complex output can be defined for contracts.
@@ -28,13 +26,13 @@ model_rate = fit(Spline.Linear(),q_rate);⠀
 model_spread = fit(Spline.Linear(),q_spread);
 
 # the zero rate is the combination of the two underlying rates
-zero(m_spread + m_rate,1) # 0.02 annual effective rate 
+zero(model_spread + model_rate,1) # 0.02 annual effective rate
 
-# the discount is the same as if we added the underlying zero rates
-discount(m_spread + m_rate,0,3) ≈ discount(0.01 + 0.03,3)   # true
+# the discount is the product of the individual discount factors
+discount(model_spread + model_rate,0,3) ≈ discount(model_spread,0,3) * discount(model_rate,0,3)   # true
 
 # compute the present value of a contract (a cashflow of 10 at time 3)
-present_value(m_rate,Cashflow(10,3)) # 9.15...
+present_value(model_rate,Cashflow(10,3)) # 9.15...
 ```
 
 ## Overview of FinanceModels
@@ -308,11 +306,11 @@ convert(FinanceModels.Continuous(),r)          # convert monthly rate to continu
 
 #### Arithmetic
 
-Adding, substracting, multiplying, dividing, and comparing rates is supported.
+Adding, subtracting, multiplying, dividing, and comparing rates is supported.
 
 ## Guide and Documentation
 
-A guide which explains more about the components of the package and from-scratch examples of extending the package is available in the [documenation](https://docs.juliaactuary.org/FinanceModels/dev/)
+A guide which explains more about the components of the package and from-scratch examples of extending the package is available in the [documentation](https://docs.juliaactuary.org/FinanceModels/dev/)
 
 ## Exported vs Un-exported Functions
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,13 +30,13 @@ model_rate = fit(Spline.Linear(),q_rate,Fit.Bootstrap());⠀
 model_spread = fit(Spline.Linear(),q_spread,Fit.Bootstrap());
 
 # the zero rate is the combination of the two underlying rates
-zero(m_spread + m_rate,1) # 0.02 annual effective rate 
+zero(model_spread + model_rate,1) # 0.02 annual effective rate
 
-# the discount is the same as if we added the underlying zero rates
-discount(m_spread + m_rate,0,3) ≈ discount(0.01 + 0.03,3)   # true
+# the discount is the product of the individual discount factors
+discount(model_spread + model_rate,0,3) ≈ discount(model_spread,0,3) * discount(model_rate,0,3)   # true
 
 # compute the present value of a contract (a cashflow of 10 at time 3)
-present_value(m_rate,Cashflow(10,3)) # 9.15...
+present_value(model_rate,Cashflow(10,3)) # 9.15...
 ```
 
 ## Overview of FinanceModels
@@ -182,9 +182,6 @@ julia> fit(Spline.PolynomialSpline(3), q_rate, Fit.Bootstrap()) # after importin
 
 ```
 
-> [!NOTE]
-> This was built-in prior to v4.9 of FinanceModels. It has been split out to materially speed up `using FinanceModels`.
-
 ### Projections
 
 Most basically, we can project a contract into a series of `Cashflow`s:
@@ -231,8 +228,6 @@ stem(proj)
 Will produce:
 
 ![A stem plot of bond cashflows](https://github.com/JuliaActuary/ActuaryUtilities.jl/assets/711879/29480ce2-9691-4eb5-b656-a05394f7a2c2)
-
-### Fitting Models
 
 ### Fitting Models
 
@@ -305,25 +300,17 @@ convert(FinanceModels.Continuous(),r)          # convert monthly rate to continu
 
 #### Arithmetic
 
-Adding, substracting, multiplying, dividing, and comparing rates is supported.
+Adding, subtracting, multiplying, dividing, and comparing rates is supported.
 
 ## Guide and Documentation
 
-A guide which explains more about the components of the package and from-scratch examples of extending the package is available in the [documenation](https://docs.juliaactuary.org/FinanceModels/dev/)
+A guide which explains more about the components of the package and from-scratch examples of extending the package is available in the [documentation](https://docs.juliaactuary.org/FinanceModels/dev/)
 
 ## Exported vs Un-exported Functions
 
 Generally, CamelCase methods which construct a datatype are exported as they are unlikely to conflict with other parts of code that may be written. For example, `rate` is un-exported (it must be called with `FinanceModels.rate(...)`) because `rate` is likely a very commonly defined variable within actuarial and financial contexts and there is a high risk of conflicting with defined variables.
 
 Consider using `import FinanceModels` which would require qualifying all methods, but alleviates any namespace conflicts and has the benefit of being explicit about the calls (internally we prefer this in the package design to keep dependencies and their usage clear).
-
-## Internals
-
-For time-variant FinanceModels (ie yield *curves*), the inputs are converted to spot rates and interpolated using quadratic B-splines by default (see documentation for alternatives, such as linear interpolations).
-
-### Combination Implementation
-
-[Combinations](#combinations) track two different curve objects and are not combined into a single underlying data structure. This means that you may achieve better performance if you combine the rates before constructing a `FinanceModels` representation. The exception to this is `Constant` curves, which *do* get combined into a single structure that is as performant as pre-combined rate structure.
 
 ## Related Packages
 

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -19,8 +19,8 @@ Rates are types that wrap scalar values to provide information about how to dete
 
 There are two `Frequency` types:
 
-- `Yields.Periodic(m)` for rates that compound `m` times per period (e.g. `m` times per year if working with annual rates).
-- `Yields.Continuous()` for continuously compounding rates.
+- `Periodic(m)` for rates that compound `m` times per period (e.g. `m` times per year if working with annual rates).
+- `Continuous()` for continuously compounding rates.
 
 #### Examples
 
@@ -57,8 +57,8 @@ Convert rates between different types with `convert`. E.g.:
 ```julia
 r = Rate(0.01,Periodic(12))             # rate that compounds 12 times per rate period (ie monthly)
 
-convert(Yields.Periodic(1),r)                  # convert monthly rate to annual effective
-convert(Yields.Continuous(),r)          # convert monthly rate to continuous
+convert(Periodic(1),r)                  # convert monthly rate to annual effective
+convert(Continuous(),r)          # convert monthly rate to continuous
 ```
 
 To get the scalar value out of the `Rate`, use `FinanceModels.rate(r)`:
@@ -97,17 +97,17 @@ julia> q_rate = ZCBYield([0.01,0.02,0.03]);
 
 julia> q_spread = ZCBYield([0.01,0.01,0.01]);
 
-julia> m_rate = fit(Spline.Linear(),q_rate,Fit.Bootstrap());⠀           
+julia> model_rate = fit(Spline.Linear(),q_rate,Fit.Bootstrap());⠀
 
-julia> m_spread = fit(Spline.Linear(),q_spread,Fit.Bootstrap());
+julia> model_spread = fit(Spline.Linear(),q_spread,Fit.Bootstrap());
 
-julia> forward(m_spread + m_rate,0,1)
+julia> forward(model_spread + model_rate,0,1)
 Rate{Float64, Continuous}(0.01980262729617973, Continuous())
 
-julia> forward(m_spread + m_rate,0,1) |> Periodic(1)
+julia> forward(model_spread + model_rate,0,1) |> Periodic(1)
 Rate{Float64, Periodic}(0.020000000000000018, Periodic(1))
 
-julia> discount(m_spread + m_rate,0,3)
+julia> discount(model_spread + model_rate,0,3)
 0.8889963586709149
 
 julia> discount(0.04,3)
@@ -125,15 +125,15 @@ julia> discount(0.04,3)
     q_spread = ParYield([0.01,0.01,0.01]);
     q_yield = ParYield([0.02,0.03,0.04]);
 
-    m_rate = fit(Spline.Linear(),q_rate,Fit.Bootstrap());         
-    m_spread = fit(Spline.Linear(),q_spread,Fit.Bootstrap());
-    m_yield = fit(Spline.Linear(),q_yield,Fit.Bootstrap());
+    model_rate = fit(Spline.Linear(),q_rate,Fit.Bootstrap());
+    model_spread = fit(Spline.Linear(),q_spread,Fit.Bootstrap());
+    model_yield = fit(Spline.Linear(),q_yield,Fit.Bootstrap());
 
     # The curves are different!
-    discount(m_spread + m_rate,3)
+    discount(model_spread + model_rate,3)
     # 0.8889963586709149
 
-    discount(m_yield,3)
+    discount(model_yield,3)
     # 0.8864366955434709
     ```
 


### PR DESCRIPTION
## Summary

- Bumps package version from 4.18.1 to 5.0.0
- Fixes stale content across README and documentation pages accumulated over the v4.x lifecycle

## Changes

**Version bump**
- `Project.toml`: 4.18.1 → 5.0.0

**QuickStart examples** (README.md, docs/src/index.md)
- Fix undefined variables `m_spread`/`m_rate` → `model_spread`/`model_rate`
- Update discount example to show DF-product semantics (`discount(a,t) * discount(b,t)`)

**README.md**
- Remove stale Yields.jl migration note (package was renamed years ago)

**docs/src/index.md**
- Remove outdated "Internals > Combination Implementation" section (references old EA-rate behavior, pre-CZR semantics)
- Remove stale UnicodePlots v4.9 version note
- Remove duplicate "### Fitting Models" header
- Fix typos ("substracting" → "subtracting", "documenation" → "documentation")

**docs/src/models.md**
- Fix stale `Yields.Periodic` / `Yields.Continuous` → `Periodic` / `Continuous` (4 occurrences)
- Fix `m_rate`/`m_spread`/`m_yield` → `model_rate`/`model_spread`/`model_yield`

## Test plan

- [x] Full test suite passes (`Pkg.test()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)