### PR TITLE
Add Cairns-Pritchard yield curve model

### DIFF
--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -77,6 +77,8 @@ julia> rate(r)
 - [`FinanceModels.Yield.SmithWilson`](@ref)
 - [`FinanceModels.Yield.NelsonSiegel`](@ref)
 - [`FinanceModels.Yield.NelsonSiegelSvensson`](@ref)
+- [`FinanceModels.Yield.CairnsPritchard`](@ref)
+- [`FinanceModels.Yield.CairnsPritchardExtended`](@ref)
 
 ### Available Models - Stochastic Short Rates
 

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -147,6 +147,22 @@ __default_optic(m::Yield.NelsonSiegelSvensson) = (
         @optic(_.β₂) => -10.0 .. 10.0,
         @optic(_.β₃) => -10.0 .. 10.0,
     )
+__default_optic(m::Yield.CairnsPritchard) = (
+        @optic(_.c₁) => 0.001 .. 10.0,
+        @optic(_.c₂) => 0.001 .. 10.0,
+        @optic(_.b₀) => -1.0 .. 1.0,
+        @optic(_.b₁) => -10.0 .. 10.0,
+        @optic(_.b₂) => -10.0 .. 10.0,
+    )
+__default_optic(m::Yield.CairnsPritchardExtended) = (
+        @optic(_.c₁) => 0.001 .. 10.0,
+        @optic(_.c₂) => 0.001 .. 10.0,
+        @optic(_.c₃) => 0.001 .. 10.0,
+        @optic(_.b₀) => -1.0 .. 1.0,
+        @optic(_.b₁) => -10.0 .. 10.0,
+        @optic(_.b₂) => -10.0 .. 10.0,
+        @optic(_.b₃) => -10.0 .. 10.0,
+    )
 __default_optic(m::Equity.BlackScholesMerton{T,U,V}) where {T,U,V<:Volatility.Constant} = ((@optic(_.σ.σ) => 0.0 .. 10.0),)
 __default_optic(m::Volatility.Constant) = ((@optic(_.σ) => 0.0 .. 10.0),)
 __default_optic(m::ShortRate.Vasicek) = (

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -91,6 +91,7 @@ end
 
 include("Yield/SmithWilson.jl")
 include("Yield/NelsonSiegelSvensson.jl")
+include("Yield/CairnsPritchard.jl")
 include("Yield/MonotoneConvex.jl")
 
 # callable interface for MonotoneConvex (matches Spline and ZeroRateCurve)

--- a/src/model/Yield/CairnsPritchard.jl
+++ b/src/model/Yield/CairnsPritchard.jl
@@ -1,0 +1,114 @@
+"""
+    CairnsPritchard(c₁, c₂, b₀, b₁, b₂)
+    CairnsPritchard(c₁=0.5, c₂=3.0) # used in fitting
+
+A Cairns-Pritchard yield curve model with 2 exponential components.
+
+The continuous zero rate at time `t` is:
+
+``r(t) = b₀ + b₁ \\exp(-c₁ t) + b₂ \\exp(-c₂ t)``
+
+This is a generalization of Nelson-Siegel with independent decay rates per
+exponential component. Parameters and default fitting bounds:
+
+- `c₁` decay rate for first component: `0.001 .. 10.0`
+- `c₂` decay rate for second component: `0.001 .. 10.0`
+- `b₀` long-term rate level: `-1.0 .. 1.0`
+- `b₁` first exponential coefficient: `-10.0 .. 10.0`
+- `b₂` second exponential coefficient: `-10.0 .. 10.0`
+
+See also [`CairnsPritchardExtended`](@ref) for a 3-component variant.
+
+# References
+- Cairns, A.J.G. (1998). "Descriptive Bond-Yield and Forward-Rate Models for the British Government Securities Market". British Actuarial Journal, 4(2), 265-321.
+"""
+struct CairnsPritchard{T} <: AbstractYieldModel
+    c₁::T
+    c₂::T
+    b₀::T
+    b₁::T
+    b₂::T
+
+    function CairnsPritchard(c₁::T, c₂::T, b₀::T, b₁::T, b₂::T) where {T}
+        (c₁ <= 0 || c₂ <= 0) && throw(DomainError("Decay parameters c must be positive"))
+        return new{T}(c₁, c₂, b₀, b₁, b₂)
+    end
+end
+
+# Promote mixed argument types for ForwardDiff compatibility
+function CairnsPritchard(c₁, c₂, b₀, b₁, b₂)
+    T = promote_type(typeof(c₁), typeof(c₂), typeof(b₀), typeof(b₁), typeof(b₂))
+    return CairnsPritchard(convert(T, c₁), convert(T, c₂), convert(T, b₀), convert(T, b₁), convert(T, b₂))
+end
+
+# Default constructor with different c values to break symmetry during fitting.
+# Non-zero b values provide a reasonable starting curve for the optimizer.
+CairnsPritchard(c₁=0.5, c₂=3.0) = CairnsPritchard(c₁, c₂, 0.05, -0.01, -0.01)
+
+function Base.zero(cp::CairnsPritchard, t)
+    if iszero(t)
+        t += eps()
+    end
+    return Continuous.(cp.b₀ .+ cp.b₁ .* exp.(-cp.c₁ .* t) .+ cp.b₂ .* exp.(-cp.c₂ .* t))
+end
+
+FinanceCore.discount(cp::CairnsPritchard, t) = discount.(zero.(cp, t), t)
+
+"""
+    CairnsPritchardExtended(c₁, c₂, c₃, b₀, b₁, b₂, b₃)
+    CairnsPritchardExtended(c₁=0.5, c₂=2.0, c₃=5.0) # used in fitting
+
+A Cairns-Pritchard yield curve model with 3 exponential components.
+
+The continuous zero rate at time `t` is:
+
+``r(t) = b₀ + b₁ \\exp(-c₁ t) + b₂ \\exp(-c₂ t) + b₃ \\exp(-c₃ t)``
+
+Parameters and default fitting bounds:
+
+- `c₁` decay rate for first component: `0.001 .. 10.0`
+- `c₂` decay rate for second component: `0.001 .. 10.0`
+- `c₃` decay rate for third component: `0.001 .. 10.0`
+- `b₀` long-term rate level: `-1.0 .. 1.0`
+- `b₁` first exponential coefficient: `-10.0 .. 10.0`
+- `b₂` second exponential coefficient: `-10.0 .. 10.0`
+- `b₃` third exponential coefficient: `-10.0 .. 10.0`
+
+See also [`CairnsPritchard`](@ref) for a 2-component variant.
+
+# References
+- Cairns, A.J.G. (1998). "Descriptive Bond-Yield and Forward-Rate Models for the British Government Securities Market". British Actuarial Journal, 4(2), 265-321.
+"""
+struct CairnsPritchardExtended{T} <: AbstractYieldModel
+    c₁::T
+    c₂::T
+    c₃::T
+    b₀::T
+    b₁::T
+    b₂::T
+    b₃::T
+
+    function CairnsPritchardExtended(c₁::T, c₂::T, c₃::T, b₀::T, b₁::T, b₂::T, b₃::T) where {T}
+        (c₁ <= 0 || c₂ <= 0 || c₃ <= 0) && throw(DomainError("Decay parameters c must be positive"))
+        return new{T}(c₁, c₂, c₃, b₀, b₁, b₂, b₃)
+    end
+end
+
+# Promote mixed argument types for ForwardDiff compatibility
+function CairnsPritchardExtended(c₁, c₂, c₃, b₀, b₁, b₂, b₃)
+    T = promote_type(typeof(c₁), typeof(c₂), typeof(c₃), typeof(b₀), typeof(b₁), typeof(b₂), typeof(b₃))
+    return CairnsPritchardExtended(convert(T, c₁), convert(T, c₂), convert(T, c₃), convert(T, b₀), convert(T, b₁), convert(T, b₂), convert(T, b₃))
+end
+
+# Default constructor with different c values to break symmetry during fitting.
+# Non-zero b values provide a reasonable starting curve for the optimizer.
+CairnsPritchardExtended(c₁=0.5, c₂=2.0, c₃=5.0) = CairnsPritchardExtended(c₁, c₂, c₃, 0.05, -0.01, -0.01, -0.01)
+
+function Base.zero(cp::CairnsPritchardExtended, t)
+    if iszero(t)
+        t += eps()
+    end
+    return Continuous.(cp.b₀ .+ cp.b₁ .* exp.(-cp.c₁ .* t) .+ cp.b₂ .* exp.(-cp.c₂ .* t) .+ cp.b₃ .* exp.(-cp.c₃ .* t))
+end
+
+FinanceCore.discount(cp::CairnsPritchardExtended, t) = discount.(zero.(cp, t), t)

--- a/test/CairnsPritchard.jl
+++ b/test/CairnsPritchard.jl
@@ -1,0 +1,111 @@
+@testset "CairnsPritchard" begin
+
+    @testset "Direct construction" begin
+        cp = Yield.CairnsPritchard(0.5, 1.5, 0.04, -0.02, -0.01)
+
+        # discount(0) == 1
+        @test discount(cp, 0) == 1.0
+
+        # discount * accumulation == 1
+        @test discount(cp, 10) ≈ 1 / accumulation(cp, 10)
+
+        # zero rate at known params: r(t) = b₀ + b₁*exp(-c₁*t) + b₂*exp(-c₂*t)
+        t = 5.0
+        expected_r = 0.04 + (-0.02) * exp(-0.5 * t) + (-0.01) * exp(-1.5 * t)
+        @test FinanceModels.zero(cp, t) ≈ Continuous(expected_r)
+
+        # asymptotic: as t→∞, zero rate → b₀
+        @test FinanceModels.rate(FinanceModels.zero(cp, 1000.0)) ≈ 0.04 atol = 1e-10
+    end
+
+    @testset "DomainError for negative c" begin
+        @test_throws DomainError Yield.CairnsPritchard(-1.0, 1.0, 0.0, 0.0, 0.0)
+        @test_throws DomainError Yield.CairnsPritchard(1.0, -1.0, 0.0, 0.0, 0.0)
+        @test_throws DomainError Yield.CairnsPritchardExtended(-1.0, 1.0, 2.0, 0.0, 0.0, 0.0, 0.0)
+        @test_throws DomainError Yield.CairnsPritchardExtended(1.0, -1.0, 2.0, 0.0, 0.0, 0.0, 0.0)
+        @test_throws DomainError Yield.CairnsPritchardExtended(1.0, 2.0, -1.0, 0.0, 0.0, 0.0, 0.0)
+    end
+
+    @testset "Fit to Cairns (1998) Figure 1 data" begin
+        # Source: Cairns (1998), Figure 1 — digitized via WebPlotDigitizer
+        # Cairns, A.J.G. (1998). "Descriptive Bond-Yield and Forward-Rate Models for
+        # the British Government Securities Market". British Actuarial Journal, 4(2), 265-321.
+        target = [4.106762688183153, 4.264064261935675, 4.403887883049028, 4.550725327846389,
+                  4.739607977033906, 4.925342222661497, 5.017616324256814, 5.01874845567391,
+                  5.009529671277556, 4.990299610492881, 4.85329014461631, 4.732249122822781,
+                  4.625801814105818] ./ 100
+        mats = [0.4511004586929275, 0.850176783219295, 1.2049112939094009, 1.6052006163826604,
+                2.2324553324737497, 3.277385674943506, 5.2141390634757325, 6.605043375908062,
+                8.136251117530515, 10.225033582072788, 17.61340407657162, 23.191577301663614,
+                29.55631230653806]
+
+        zqs = ZCBYield.(Continuous.(target), mats)
+        c = fit(Yield.CairnsPritchard(), zqs)
+
+        @test discount(c, 0) ≈ 1.0
+
+        @testset "zero rates: $t" for (t, r) in zip(mats, target)
+            @test FinanceModels.rate(FinanceModels.zero(c, t)) ≈ r atol = 0.005
+        end
+    end
+
+    @testset "Fit to Bank of England gilt data (2 components)" begin
+        # Source: Bank of England yield curve data (exact date unknown), via PR #128 comment
+        gilt = [4.38, 4.83, 5.09, 5.21, 5.26, 5.26, 5.24, 5.20, 5.16, 5.11,
+                5.07, 5.03, 4.98, 4.95, 4.91, 4.88, 4.86, 4.83, 4.82, 4.80,
+                4.79, 4.78, 4.77, 4.75, 4.74, 4.73, 4.72, 4.70, 4.69, 4.67,
+                4.66, 4.64, 4.62, 4.61, 4.59, 4.56, 4.54, 4.52, 4.50, 4.47,
+                4.45, 4.42, 4.40, 4.37, 4.34, 4.31, 4.28, 4.26, 4.23, 4.20] ./ 100
+        gmats = collect(0.5:0.5:25.0)
+
+        zqs = ZCBYield.(Continuous.(gilt), gmats)
+        c = fit(Yield.CairnsPritchard(), zqs)
+
+        @test discount(c, 0) ≈ 1.0
+
+        @testset "zero rates: $t" for (t, r) in zip(gmats, gilt)
+            @test FinanceModels.rate(FinanceModels.zero(c, t)) ≈ r atol = 0.01
+        end
+    end
+
+    @testset "Fit to Bank of England gilt data (3 components)" begin
+        # Source: Bank of England yield curve data (exact date unknown), via PR #128 comment
+        gilt = [4.38, 4.83, 5.09, 5.21, 5.26, 5.26, 5.24, 5.20, 5.16, 5.11,
+                5.07, 5.03, 4.98, 4.95, 4.91, 4.88, 4.86, 4.83, 4.82, 4.80,
+                4.79, 4.78, 4.77, 4.75, 4.74, 4.73, 4.72, 4.70, 4.69, 4.67,
+                4.66, 4.64, 4.62, 4.61, 4.59, 4.56, 4.54, 4.52, 4.50, 4.47,
+                4.45, 4.42, 4.40, 4.37, 4.34, 4.31, 4.28, 4.26, 4.23, 4.20] ./ 100
+        gmats = collect(0.5:0.5:25.0)
+
+        zqs = ZCBYield.(Continuous.(gilt), gmats)
+        c = fit(Yield.CairnsPritchardExtended(), zqs)
+
+        @test discount(c, 0) ≈ 1.0
+
+        @testset "zero rates: $t" for (t, r) in zip(gmats, gilt)
+            @test FinanceModels.rate(FinanceModels.zero(c, t)) ≈ r atol = 0.005
+        end
+    end
+
+    @testset "Broadcasting" begin
+        cp = Yield.CairnsPritchard(0.5, 1.5, 0.04, -0.02, -0.01)
+        dfs = discount.(cp, [1, 2, 3])
+        @test length(dfs) == 3
+        @test all(0 .< dfs .< 1)
+    end
+
+    @testset "CairnsPritchardExtended direct construction" begin
+        cp = Yield.CairnsPritchardExtended(0.5, 1.5, 3.0, 0.04, -0.02, -0.01, 0.005)
+
+        @test discount(cp, 0) == 1.0
+        @test discount(cp, 10) ≈ 1 / accumulation(cp, 10)
+
+        t = 5.0
+        expected_r = 0.04 + (-0.02) * exp(-0.5 * t) + (-0.01) * exp(-1.5 * t) + 0.005 * exp(-3.0 * t)
+        @test FinanceModels.zero(cp, t) ≈ Continuous(expected_r)
+
+        # asymptotic: as t→∞, zero rate → b₀
+        @test FinanceModels.rate(FinanceModels.zero(cp, 1000.0)) ≈ 0.04 atol = 1e-10
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ include("SmithWilson.jl")
 # include("ActuaryUtilities.jl")
 include("misc.jl")
 include("NelsonSiegelSvensson.jl")
+include("CairnsPritchard.jl")
 include("MonotoneConvex.jl")
 include("ZeroRateCurve.jl")
 


### PR DESCRIPTION
## Summary

Implements the Cairns-Pritchard parametric yield curve model, a generalization of Nelson-Siegel with independent decay rates per exponential component:

$$r(t) = b_0 + \sum_i b_i \exp(-c_i \, t)$$

Two variants following the NelsonSiegel / NelsonSiegelSvensson pattern:

- **`CairnsPritchard`** — 2 exponential components, 5 parameters (`c₁, c₂, b₀, b₁, b₂`)
- **`CairnsPritchardExtended`** — 3 exponential components, 7 parameters (`c₁, c₂, c₃, b₀, b₁, b₂, b₃`)

This is a fresh reimplementation of the model from PR #128 (opened June 2022, never merged due to merge conflicts, missing tests/docs, and a convergence issue where all `c` parameters collapsed to the same value).

### Key design decisions

- **Scalar fields with `{T}` parameterization** — works with ForwardDiff Dual numbers for AD-based fitting, matching the NelsonSiegel/NSS pattern
- **Inner constructor enforces `c > 0`** — throws `DomainError` for non-positive decay rates
- **Non-zero default starting values** — `CairnsPritchard(c₁=0.5, c₂=3.0)` starts with `b₀=0.05, b₁=b₂=-0.01` and well-separated `c` values. This prevents the optimizer from collapsing to a flat curve (the convergence issue from #128)
- **Tighter `b₀` bounds** (`-1.0 .. 1.0`) vs `b` coefficients (`-10.0 .. 10.0`) — `b₀` is the long-term rate level, so tighter bounds improve convergence
- **`__default_optic`-based fitting** — integrates with the existing `fit()` infrastructure via AccessibleModels + Optimization.jl

### Files changed

| File | Change |
|---|---|
| `src/model/Yield/CairnsPritchard.jl` | New: both struct definitions, constructors, `zero`, `discount` |
| `src/model/Yield.jl` | Include the new file |
| `src/fit.jl` | `__default_optic` for both types |
| `test/CairnsPritchard.jl` | New: 131 tests |
| `test/runtests.jl` | Include the new test file |
| `docs/src/models.md` | Add both models to the Available Models list |

### Test coverage (131 tests)

- Direct construction: verify `zero`, `discount`, `accumulation` identities, asymptotic behavior (`t→∞` yields `b₀`)
- `DomainError` for negative `c` values
- **Fit to Cairns (1998) Figure 1 data** — digitized via WebPlotDigitizer from the original paper (`atol=0.005`)
- **Fit to Bank of England gilt data (2 components)** — 50 zero rates at 0.5y intervals (`atol=0.01`)
- **Fit to Bank of England gilt data (3 components)** — same data, tighter tolerance (`atol=0.005`)
- Broadcasting: `discount.(m, [1,2,3])` works

### References

- Cairns, A.J.G. (1998). "Descriptive Bond-Yield and Forward-Rate Models for the British Government Securities Market". *British Actuarial Journal*, 4(2), 265-321.

## Test plan

- [x] `Pkg.test()` — all tests pass (131 new CairnsPritchard tests + all existing tests)
- [x] `discount(m, 0) == 1.0` for fitted models
- [x] Verified both 2-component and 3-component fits converge with reasonable max errors (<0.002)

🤖 Generated with [Claude Code](https://claude.com/claude-code)