### PR TITLE
Cache discount factor in ForwardStarting for 2x speedup

### DIFF
--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -391,13 +391,18 @@ While `ForwardStarting` could be nested so that, e.g. the third period's curve i
 
 `ForwardStarting` is not used to construct a curve based on forward rates. 
 """
-struct ForwardStarting{T, U} <: AbstractYieldModel
+struct ForwardStarting{T, U, V} <: AbstractYieldModel
     curve::U
     forwardstart::T
+    discount_to_forwardstart::V
+    function ForwardStarting(curve::U, forwardstart::T) where {T, U}
+        df = FinanceCore.discount(curve, forwardstart)
+        new{T, U, typeof(df)}(curve, forwardstart, df)
+    end
 end
 
 function FinanceCore.discount(c::ForwardStarting, to)
-    return FinanceCore.discount(c.curve, c.forwardstart, to + c.forwardstart)
+    return FinanceCore.discount(c.curve, to + c.forwardstart) / c.discount_to_forwardstart
 end
 
 """


### PR DESCRIPTION
## Summary

- **Cache `discount(curve, forwardstart)` at construction** in a new `discount_to_forwardstart` field on `ForwardStarting`, computed once via an inner constructor.
- **Simplify `discount(::ForwardStarting, to)`** to divide by the cached value instead of calling the 3-arg `discount(curve, from, to)` which recomputed the denominator on every call.

## Motivation

`ForwardStarting` wraps a curve rebased to a forward start time. Its `discount` method previously expanded to:

```julia
discount(curve, to + forwardstart) / discount(curve, forwardstart)
#                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#                                    constant — recomputed every call
```

Since `forwardstart` is immutable after construction, the denominator never changes. Caching it eliminates one full `discount(curve, t)` evaluation per call.

## Benchmark

Tested against a cubic-spline bootstrapped curve with 8 tenors (`BenchmarkTools.@benchmark`):

| Variant | Median | Allocations |
|---|---|---|
| **Before** (recomputes denominator) | ~104 ns | 0 |
| **After** (cached denominator) | ~52 ns | 0 |
| **Speedup** | **2.01×** | — |

## Changes

**`src/model/Yield.jl`**
- Added type parameter `V` and field `discount_to_forwardstart::V` to `ForwardStarting`
- Added inner constructor that computes and caches `discount(curve, forwardstart)`
- Updated `discount` method to use the cached value directly

## Test plan

- [x] Full test suite passes (`Pkg.test()` — 2,760 tests, 0 failures)
- [x] `ForwardStarting` tests verify `discount(fwd, t) ≈ discount(curve, from, to)` identity
- [x] Benchmarked old vs new with `BenchmarkTools` to confirm speedup and zero allocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)