### PR TITLE
AbstractYieldModel <: AbstractDeflator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceModels"
 uuid = "77f2ae65-bdde-421f-ae9d-22f1af19dd76"
-version = "5.3.0"
+version = "5.4.0"
 authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
 
 [deps]
@@ -37,7 +37,7 @@ Accessors = "^0.1"
 DataInterpolations = "8"
 Dates = "^1.6"
 DifferentiationInterface = "0.7.4"
-FinanceCore = "^2.3"
+FinanceCore = "^2.6"
 IntervalSets = "^0.7"
 LinearAlgebra = "1"
 MakieCore = "0.8,0.9"

--- a/src/model/Model.jl
+++ b/src/model/Model.jl
@@ -7,8 +7,13 @@ A singleton type representing a placeholder model for when you don't really need
 """
 struct NullModel <: AbstractModel end
 
-# useful for round-tripping or iterating on quotes?
+# useful for round-tripping or iterating on quotes
+# Accepts both `AbstractModel` (Equity, Volatility, NullModel) and
+# `AbstractDeflator` (yield curves — no longer a subtype of AbstractModel).
 function FinanceCore.Quote(m::M, c::C) where {M <: AbstractModel, C <: FinanceCore.AbstractContract}
+    return FinanceCore.Quote(pv(m, c), c)
+end
+function FinanceCore.Quote(m::M, c::C) where {M <: FinanceCore.AbstractDeflator, C <: FinanceCore.AbstractContract}
     return FinanceCore.Quote(pv(m, c), c)
 end
 

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -5,11 +5,15 @@ import ..Spline as Sp
 import ..DataInterpolations
 import ..Bond: coupon_times
 
-using ..FinanceCore: Continuous, Periodic, discount, accumulation, AbstractContract
+using ..FinanceCore: Continuous, Periodic, discount, accumulation, AbstractContract,
+    AbstractDeflator, factor, intensity
 
 export discount, zero, forward, par, pv
 
-abstract type AbstractYieldModel <: AbstractModel end
+# Yield curves are deflators: `factor(yc, from, to)` is the discount factor.
+# Subtyping `AbstractDeflator` makes every yield curve compose with mortality,
+# lapse, default, and other decrement processes via `compose(...)`.
+abstract type AbstractYieldModel <: AbstractDeflator end
 
 """
     Constant(rate)
@@ -118,6 +122,12 @@ include("Yield/ZeroRateCurve.jl")
 The discount factor for the yield curve `yc` for times `from` through `to`.
 """
 FinanceCore.discount(yc::T, from, to) where {T <: AbstractYieldModel} = discount(yc, to) / discount(yc, from)
+
+# AbstractDeflator interface: `factor` is the discount factor for yield curves.
+# Each concrete yield model already defines `discount(yc, t)`; the two-argument
+# form derives via the existing `discount(yc, from, to)` method above.
+FinanceCore.factor(yc::T, t)        where {T <: AbstractYieldModel} = discount(yc, t)
+FinanceCore.factor(yc::T, from, to) where {T <: AbstractYieldModel} = discount(yc, from, to)
 
 """
     forward(yc, from, to)˚

--- a/test/AbstractDeflator.jl
+++ b/test/AbstractDeflator.jl
@@ -1,0 +1,71 @@
+@testset "AbstractDeflator integration" begin
+    @testset "AbstractYieldModel <: AbstractDeflator" begin
+        @test FinanceModels.Yield.AbstractYieldModel <: FinanceCore.AbstractDeflator
+        c = FinanceModels.Yield.Constant(0.04)
+        @test c isa FinanceCore.AbstractDeflator
+    end
+
+    @testset "factor agrees with discount on yield curves" begin
+        # Use a continuous-force constant yield so we can compare to exp(-r*t)
+        c = FinanceModels.Yield.Constant(FinanceCore.Continuous(0.04))
+        @test FinanceCore.factor(c, 5) ≈ FinanceCore.discount(c, 5)
+        @test FinanceCore.factor(c, 1, 6) ≈ FinanceCore.discount(c, 1, 6)
+        @test FinanceCore.factor(c, 1, 6) ≈ exp(-0.04 * 5)
+
+        # Spline yield curve, a non-trivial term structure
+        zc = FinanceModels.fit(
+            FinanceModels.Spline.Linear(),
+            FinanceModels.ZCBYield.([0.03, 0.035, 0.04, 0.045], [1, 2, 5, 10]),
+            FinanceModels.Fit.Bootstrap()
+        )
+        @test FinanceCore.factor(zc, 5) ≈ FinanceCore.discount(zc, 5)
+        @test FinanceCore.factor(zc, 1, 6) ≈ FinanceCore.discount(zc, 1, 6)
+    end
+
+    @testset "compose yield × decrement" begin
+        # The headline workflow: yield × default-survival composition.
+        # Use Continuous(0.03) so the composite force is exactly 0.042 = 0.03 + 0.012.
+        yield = FinanceModels.Yield.Constant(FinanceCore.Continuous(0.03))
+        λ_d   = FinanceCore.Continuous(0.012)         # 1.2% default hazard
+        deflator = FinanceCore.compose(yield, λ_d)
+
+        @test deflator isa FinanceCore.CompositeDeflator
+        @test FinanceCore.factor(deflator, 0, 5) ≈
+            FinanceCore.factor(yield, 0, 5) * FinanceCore.factor(λ_d, 0, 5)
+        @test FinanceCore.factor(deflator, 0, 5) ≈ exp(-0.042 * 5)
+
+        # pv integration with a Cashflow vector
+        cashflows = [FinanceCore.Cashflow(100.0, t) for t in 1.0:5.0]
+        expected = sum(100.0 * exp(-0.042 * t) for t in 1.0:5.0)
+        @test FinanceCore.pv(deflator, cashflows) ≈ expected
+    end
+
+    @testset "term-structure yield × constant decrement" begin
+        # Real term-structure yield curve composed with mortality force
+        zc = FinanceModels.fit(
+            FinanceModels.Spline.Cubic(),
+            FinanceModels.ZCBYield.([0.03, 0.035, 0.04, 0.045, 0.05], [1, 2, 3, 5, 10]),
+            FinanceModels.Fit.Bootstrap()
+        )
+        μ = FinanceCore.Continuous(0.012)
+        deflator = FinanceCore.compose(zc, μ)
+        # Each cashflow's factor combines the curve's spot discount with
+        # the mortality survival from time 0
+        for t in (1.0, 5.0, 10.0)
+            @test FinanceCore.factor(deflator, t) ≈
+                FinanceCore.factor(zc, t) * FinanceCore.factor(μ, t)
+        end
+    end
+
+    @testset "Quote dispatch works for yield models (AbstractDeflator)" begin
+        # Quote(model, contract) should still work for yield models even though
+        # they no longer subtype AbstractModel — we add an AbstractDeflator method.
+        yc = FinanceModels.Yield.Constant(FinanceCore.Continuous(0.04))
+        # Use the Bond.Fixed contract from a ZCBYield quote as the contract argument
+        zcb_quote = FinanceModels.ZCBYield(0.04, 5)
+        bond = zcb_quote.instrument
+        q = FinanceCore.Quote(yc, bond)
+        @test q isa FinanceCore.Quote
+        @test q.price ≈ FinanceCore.pv(yc, bond)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,4 +27,5 @@ include("ZeroRateCurve.jl")
 
 include("extensions.jl")
 include("Stochastic.jl")
+include("AbstractDeflator.jl")
 #TODO EconomicScenarioGenerators.jl integration tests


### PR DESCRIPTION
## Summary

Yield curves now subtype `FinanceCore.AbstractDeflator` (introduced in [FinanceCore #39](https://github.com/JuliaActuary/FinanceCore.jl/pull/39), v2.6.0), making every concrete yield model — `Constant`, `Spline`, `MonotoneConvex`, `SmithWilson`, `NelsonSiegelSvensson`, `CairnsPritchard`, `ZeroRateCurve`, plus the stochastic short-rate models `Vasicek`, `CIR`, and `HullWhite` — composable with mortality, lapse, default, and other decrement processes via `FinanceCore.compose(...)`.

## Changes

**`src/model/Yield.jl`** — `AbstractYieldModel <: AbstractDeflator` (was `<: AbstractModel`); two-line `factor` plumbing routes through each subtype's existing `discount`:
```julia
FinanceCore.factor(yc::AbstractYieldModel, t)        = discount(yc, t)
FinanceCore.factor(yc::AbstractYieldModel, from, to) = discount(yc, from, to)
```

**`src/model/Model.jl`** — `FinanceCore.Quote(model, contract)` widened to dispatch on either `AbstractModel` (Equity, Volatility, NullModel) or `AbstractDeflator` (yield models). The supertype move took yield models out from under `AbstractModel`; this preserves the existing `Quote(yc, bond)` workflow.

**`Project.toml`** — `FinanceCore` compat bumped to `^2.6`; FinanceModels version bumped to `5.4.0`.

**`test/AbstractDeflator.jl`** (new) — 16 tests covering:
- `AbstractYieldModel <: AbstractDeflator` + concrete subtype inheritance
- `factor` ≡ `discount` on `Constant` and `Spline` curves
- The headline workflow: `compose(yield, default_force)` produces a `CompositeDeflator` whose `factor` is the product, integrating cleanly with `pv` on a `Cashflow` vector
- Term-structure yield × constant mortality decrement composition
- `Quote(model, contract)` dispatch through the new `AbstractDeflator` method

## Why this matters

Before this change, computing the EPV of a defaultable contingent annuity required combining two parallel APIs (yields' `discount`, FinanceCore's separate decrement story). After:

```julia
yield = Yield.fit(Spline.Cubic(), CMTYield.(rates, mats), Fit.Bootstrap())
λ_d   = Continuous(0.012)
ELGD  = 0.60
defaultable_pv = pv(compose(yield, λ_d * ELGD), cashflows)
```

One composition, one `pv` call. The same workflow extends to mortality and lapse once MortalityTables.jl adopts the abstraction — see the cross-package PR series.

## Coordination

Depends on FinanceCore [#39](https://github.com/JuliaActuary/FinanceCore.jl/pull/39) being merged and `2.6.0` released. Locally tested via `Pkg.develop` against the FinanceCore branch.

## Test plan

- [x] All existing tests pass (no regressions)
- [x] 16 new `AbstractDeflator` integration tests pass
- [ ] Reviewer to verify CI passes once FinanceCore 2.6.0 is released
- [ ] Optional manual benchmark: `pv(yc, cashflows)` regression check against pre-PR baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)