### PR TITLE
Trigger CI on tag pushes so deploydocs publishes versioned docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     branches: [master]
+    tags: ['*']
 jobs:
   test: # from https://github.com/simeonschaub/OptionalArgChecks.jl/blob/457488ef04ed68a37aff10af1cb3909f47a8230c/.github/workflows/ci.yml#L23-L37
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceModels"
 uuid = "77f2ae65-bdde-421f-ae9d-22f1af19dd76"
-version = "5.3.0"
+version = "5.3.1"
 authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary

The CI workflow only triggers on master pushes and PRs, never on tag pushes. When TagBot creates a release tag, no CI run fires against the tag, so `deploydocs` never publishes the versioned `/vX.Y.Z/` directory and the `stable` symlink never advances.

As a result, `https://docs.juliaactuary.org/FinanceModels/stable/` is currently at **v4.17.1**, while the latest release is **v5.3.0** (2026-03-19) — several major versions behind.

Adding `tags: ['*']` makes the next tag trigger a docs build that publishes the corresponding versioned dir and advances `stable`. This matches the standard Documenter recommendation and the existing config in `FinanceCore.jl`, `EconomicScenarioGenerators.jl`, and `TermLife.jl`.

## Test plan

- [ ] PR CI passes (same as today's master CI behavior)
- [ ] After merge + next tag, confirm a `/vX.Y.Z/` directory appears under `docs.juliaactuary.org/FinanceModels/` and the `stable` symlink advances

🤖 Generated with [Claude Code](https://claude.com/claude-code)