### PR TITLE
Bond.Floating: fix coupon to in-advance convention

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceModels"
 uuid = "77f2ae65-bdde-421f-ae9d-22f1af19dd76"
-version = "5.3.1"
+version = "5.4.0"
 authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
 
 [deps]

--- a/src/Projection.jl
+++ b/src/Projection.jl
@@ -136,10 +136,12 @@ end
         freq = b.frequency # e.g. `Periodic(2)`
         freq_scalar = freq.frequency  # the 2 from `Periodic(2)`
 
-        # get the rate from the current time to next payment
-        # out of the model and convert it to the contract's periodicity
+        # Fix-in-advance: the coupon paid at t reflects the forward rate
+        # observed at the START of the accrual period [t - 1/freq, t].
+        # This matches the standard market convention for FRNs and Ibor coupons,
+        # and avoids referencing a rate beyond the bond's maturity for the final coupon.
         model = p.model[b.key]
-        reference_rate = rate(freq(forward(model, t, t + 1 / freq_scalar)))
+        reference_rate = rate(freq(forward(model, t - 1 / freq_scalar, t)))
         coup = (reference_rate + b.coupon_rate) / freq_scalar
         amt = if t == last(ts)
             1.0 + coup

--- a/test/sp.jl
+++ b/test/sp.jl
@@ -62,6 +62,27 @@ end
     @test all(collect(p) .≈ [Cashflow(0.07, 1.0), Cashflow(0.07, 2.0), Cashflow(1.07, 3.0)])
 end
 
+@testset "Floating Bond: fix-in-advance" begin
+    # A non-flat curve discriminates the two possible conventions:
+    #   in-advance: coupon paid at t uses forward(t - Δ, t)
+    #   in-arrears: coupon paid at t uses forward(t, t + Δ)
+    base = FinanceModels.ZeroRateCurve(
+        [0.02, 0.03, 0.04, 0.05],
+        [1.0,  2.0,  3.0,  4.0],
+        FinanceModels.Spline.Linear(),
+    )
+    floater = Bond.Floating(0.0, Periodic(1), 3.0, "BASE")
+    p   = Projection(floater, Dict("BASE" => base), CashflowProjection())
+    cfs = collect(p)
+
+    fwd01 = rate(Periodic(1)(forward(base, 0.0, 1.0)))
+    fwd12 = rate(Periodic(1)(forward(base, 1.0, 2.0)))
+    fwd23 = rate(Periodic(1)(forward(base, 2.0, 3.0)))
+    @test cfs[1].amount ≈ fwd01
+    @test cfs[2].amount ≈ fwd12
+    @test cfs[3].amount ≈ fwd23 + 1.0
+end
+
 @testset "Composite Contracts" begin
     a = Bond.Fixed(0.05, Periodic(1), 3.0)
     b = Bond.Fixed(0.1, Periodic(4), 3.0)


### PR DESCRIPTION
## Summary

`Bond.Floating`'s `Projection` set each coupon to `forward(t, t + 1/freq)` — the rate observed at the *end* of the accrual period, looking forward one more period. Two issues with that convention:

1. **Non-standard.** The market convention for FRNs and Ibor-style coupons is fix-in-advance: the coupon paid at `t` is set by the forward rate observed at the *start* of the accrual period `[t - 1/freq, t]`. Every traded FRN, swap floating leg, and Ibor cap I'm aware of uses this convention, and so does QuantLib's `FloatingRateBond` (which requires `inArrears=True` plus a coupon pricer to reproduce the previous JA behaviour).

2. **Off-the-end extrapolation.** The previous formula made the *final* coupon reference `forward(maturity, maturity + 1/freq)`, which forces the discount curve to extrapolate past the bond's life. Under fix-in-advance the final coupon uses `forward(maturity - 1/freq, maturity)`, which lives entirely within the curve's support.

The patch is one line in `src/Projection.jl`. The existing flat-curve floating-bond test (`@testset "Floating Bonds"`) and the par-swap test are invariant to the convention (every forward on a flat curve is equal), so they continue to pass without modification. A new test with a rising non-flat curve pins down the in-advance behaviour.

## Test plan

- [x] `@testset "Floating Bonds"` (existing flat-curve test) — still passes
- [x] `@testset "Composite Contracts"` (par swap test using a floating leg) — still passes
- [x] `@testset "Floating Bond: fix-in-advance"` (new, non-flat curve) — passes

Cross-checked end-to-end against QuantLib 1.42.1: with this patch on the FM side and QuantLib's default `FloatingRateBond` settings (no `inArrears`, no Black coupon pricer) on the QL side, both libraries produce identical price, IR01, CS01, KRDs, and convexities on a 5y semi-annual floater under a term-structured base and credit-spread curve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)