### PR TITLE
Collapse ZeroRateCurve into a factory function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceModels"
 uuid = "77f2ae65-bdde-421f-ae9d-22f1af19dd76"
-version = "5.5.1"
+version = "5.6.0"
 authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
 
 [deps]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -113,7 +113,7 @@ The models can be used to compute various rates of interest:
 
 #### `ZeroRateCurve` — direct construction
 
-Construct a zero-rate curve directly from rates and tenors, without fitting:
+Construct a yield curve directly from zero rates and tenors, without fitting:
 
 ```julia
 rates = [0.02, 0.025, 0.03, 0.035, 0.04]
@@ -122,7 +122,7 @@ zrc = ZeroRateCurve(rates, tenors)                          # default: MonotoneC
 zrc = ZeroRateCurve(rates, tenors, Spline.Linear())          # or Linear, PCHIP, Cubic, Akima
 ```
 
-`ZeroRateCurve` is compatible with ForwardDiff dual numbers, making it the primary interface for automatic differentiation-based sensitivities in [ActuaryUtilities.jl](https://github.com/JuliaActuary/ActuaryUtilities.jl).
+`ZeroRateCurve` is a factory function — it returns the appropriate underlying curve type (`Yield.MonotoneConvex` or `Yield.Spline`) supporting the full `AbstractYieldModel` interface (`discount`, `zero`, `forward`, callable `(t)` syntax). The returned curve composes with ForwardDiff dual numbers for automatic differentiation use cases in [ActuaryUtilities.jl](https://github.com/JuliaActuary/ActuaryUtilities.jl).
 
 #### Stochastic short-rate models
 

--- a/docs/src/interpolation.md
+++ b/docs/src/interpolation.md
@@ -1,6 +1,6 @@
 # Interpolation Methods for `ZeroRateCurve`
 
-`ZeroRateCurve` accepts an optional third argument specifying the interpolation method. The choice of interpolation affects **forward curve smoothness**, **key rate duration locality**, and **performance** when used with automatic differentiation (e.g. via `sensitivities()` in ActuaryUtilities.jl).
+`ZeroRateCurve` is a factory that accepts an optional third argument specifying the interpolation method, returning an `AbstractYieldModel` (concretely `Yield.MonotoneConvex` for the default spline or `Yield.Spline` for the others). The choice of interpolation affects **forward curve smoothness**, **key rate duration locality**, and **performance** when used with automatic differentiation (e.g. via `sensitivities()` in ActuaryUtilities.jl).
 
 ## Available Methods
 

--- a/src/model/Yield/ZeroRateCurve.jl
+++ b/src/model/Yield/ZeroRateCurve.jl
@@ -2,24 +2,17 @@
     ZeroRateCurve(rates, tenors, [spline])
     ZeroRateCurve(curve::AbstractYieldModel, tenors; spline=Spline.MonotoneConvex())
 
-A yield curve defined by continuously-compounded zero rates at specified tenors,
-with interpolation between tenors via the existing `Spline` infrastructure.
+Construct an `AbstractYieldModel` from continuously-compounded zero rates at
+the given tenors, interpolated by `spline` (default: `Spline.MonotoneConvex()`).
 
-The `spline` argument is a `Spline.SplineCurve` object (e.g. `Spline.MonotoneConvex()`,
-`Spline.PCHIP()`, `Spline.Linear()`, `Spline.Cubic()`). Defaults to `Spline.MonotoneConvex()`.
+`ZeroRateCurve` is a factory function that returns the appropriate underlying
+curve type — `Yield.MonotoneConvex` for the default spline, `Yield.Spline` for
+all other splines. The returned object supports the full `AbstractYieldModel`
+interface (`discount`, `zero`, `forward`, callable `(t)` syntax, `pv`, etc.),
+so downstream code that programs against the abstract interface continues to
+work without modification.
 
-The curve stores the raw `rates` vector, making it compatible with ForwardDiff:
-construct `ZeroRateCurve(dual_rates, tenors, spline)` inside an AD closure and
-the interpolation will propagate dual numbers.
-
-## Constructing from another yield model
-
-The second form samples zero rates from any `AbstractYieldModel` (e.g. `Yield.Constant`,
-`Yield.NelsonSiegel`, a fitted spline curve, etc.) at the specified `tenors`, producing
-a `ZeroRateCurve` suitable for key rate analysis with ActuaryUtilities.jl. All tenors
-must be positive (`t > 0`).
-
-# Examples
+## Constructing from rates + tenors
 
 ```julia
 using FinanceModels
@@ -35,34 +28,44 @@ zrc_cubic = ZeroRateCurve(rates, tenors, Spline.Cubic())         # cubic
 discount(zrc, 1.0)   # exp(-0.02 * 1.0)
 discount(zrc, 3.5)   # interpolated rate at t=3.5
 zero(zrc, 5.0)       # Continuous(0.035)
+```
 
-# From a NelsonSiegel model:
+## Resampling another yield model
+
+The second form samples zero rates from any existing `AbstractYieldModel`
+(e.g. `Yield.Constant`, `Yield.NelsonSiegel`, a fitted spline curve, etc.) at
+the specified `tenors`, then re-interpolates with the chosen spline:
+
+```julia
 ns = Yield.NelsonSiegel(1.0, 0.04, -0.02, 0.01)
 zrc_ns = ZeroRateCurve(ns, [1.0, 2.0, 5.0, 10.0, 20.0])
 ```
 
-## Performance note
+All tenors must be positive (`t > 0`); the zero rate is undefined at `t = 0`.
 
-`discount` reconstructs the interpolation model on each call for AD compatibility
-(dual numbers must flow through the interpolation). For non-AD usage where `discount`
-is called many times on the same curve, construct `Yield.build_model(zrc.spline,
-zrc.tenors, zrc.rates)` once and use that instead. The AD pathway in ActuaryUtilities
-builds the model once per gradient step, avoiding this per-call overhead.
+## Why a factory function
+
+Earlier versions of FinanceModels exposed `ZeroRateCurve` as a concrete struct
+holding `(rates, tenors, spline)` with a per-call lazy rebuild of the
+interpolation model. That design existed to support an AD pathway that tagged
+`zrc.rates` with `ForwardDiff` duals; that pathway has been superseded by
+`Yield.TenorShift` bumps in ActuaryUtilities. The factory function form avoids
+the per-call rebuild and removes a redundant concrete type from the curve
+hierarchy.
+
+If you need access to the spline-resampled rates+tenors data that the old
+struct stored, compute them once at construction and keep them as local
+variables alongside the curve.
 
 ## Forward curve smoothness
 
-The default `Spline.MonotoneConvex()` guarantees positive continuous forward rates
-and produces C1-smooth forward curves ([Hagan & West, 2006](https://doi.org/10.1080/13504860600829233)).
-For C2 smoothness, use `Spline.Cubic()`. `Spline.Linear()` produces kinks in the
-forward curve at tenor points.
+The default `Spline.MonotoneConvex()` guarantees positive continuous forward
+rates and produces C1-smooth forward curves ([Hagan & West, 2006](https://doi.org/10.1080/13504860600829233)).
+For C2 smoothness, use `Spline.Cubic()`. `Spline.Linear()` produces kinks in
+the forward curve at tenor points.
 """
-struct ZeroRateCurve{R<:AbstractVector, T<:AbstractVector, S<:Sp.SplineCurve} <: AbstractYieldModel
-    rates::R      # continuously-compounded zero rates
-    tenors::T     # time points
-    spline::S     # e.g., Spline.Linear(), Spline.Cubic()
-end
-
-ZeroRateCurve(rates, tenors) = ZeroRateCurve(rates, tenors, Sp.MonotoneConvex())
+ZeroRateCurve(rates, tenors, spline = Sp.MonotoneConvex()) =
+    Yield.build_model(spline, tenors, rates)
 
 function ZeroRateCurve(curve::AbstractYieldModel, tenors; spline=Sp.MonotoneConvex())
     all(t -> t > zero(t), tenors) || throw(ArgumentError(
@@ -70,15 +73,5 @@ function ZeroRateCurve(curve::AbstractYieldModel, tenors; spline=Sp.MonotoneConv
     tenors_f = collect(float.(tenors))
     rates = [-log(FinanceCore.discount(curve, t)) / t for t in tenors_f]
     perm = sortperm(tenors_f)
-    return ZeroRateCurve(rates[perm], tenors_f[perm], spline)
+    return Yield.build_model(spline, tenors_f[perm], rates[perm])
 end
-
-function FinanceCore.discount(zrc::ZeroRateCurve, t)
-    if t <= zero(t)
-        return one(eltype(zrc.rates))
-    end
-    curve = Yield.build_model(zrc.spline, zrc.tenors, zrc.rates)
-    return discount(curve, t)
-end
-
-(zrc::ZeroRateCurve)(t) = FinanceCore.discount(zrc, t)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
-ActuaryUtilities = "bdd23359-8b1c-4f88-b89b-d11982a786f4"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 DecFP = "55939f99-70c6-5e9b-8bb0-5071ed7d61fd"
 FinanceCore = "b9b1ffdd-6612-4b69-8227-7663be06e089"


### PR DESCRIPTION
## Summary

`ZeroRateCurve` is no longer a concrete struct. It is now a factory function that constructs the appropriate underlying curve type via `Yield.build_model`:

- Default spline (`MonotoneConvex`) → returns `Yield.MonotoneConvex`
- Other splines (Linear, PCHIP, Cubic, …) → returns `Yield.Spline`

User-facing API unchanged: `ZeroRateCurve(rates, tenors)`, `ZeroRateCurve(rates, tenors, Spline.Linear())`, and `ZeroRateCurve(curve::AbstractYieldModel, tenors)` all continue to work and produce a curve supporting the full `AbstractYieldModel` interface (`discount`, `zero`, `forward`, callable `(t)`, `pv`, …).

## Why

`ZeroRateCurve` was originally a struct with a lazy per-call rebuild in `discount`:

```julia
function FinanceCore.discount(zrc::ZeroRateCurve, t)
    if t <= zero(t); return one(eltype(zrc.rates)); end
    curve = Yield.build_model(zrc.spline, zrc.tenors, zrc.rates)
    return discount(curve, t)
end
```

That existed to support an `ActuaryUtilities` AD pathway that tagged `zrc.rates` with `ForwardDiff` duals — the lazy rebuild propagated duals through every `discount` call. AU has since moved off that path (`Yield.TenorShift` bumps in AU v5.7+, see [ActuaryUtilities #139](https://github.com/JuliaActuary/ActuaryUtilities.jl/pull/139)), so the rebuild is dead overhead.

After this PR:
- The per-call rebuild is gone — `discount(zrc, t)` is a single spline evaluation.
- The hierarchy has one fewer concrete `AbstractYieldModel` subtype.
- The direct-construction path now mirrors the `fit(...)` path, which already returns `Yield.Spline` / `Yield.MonotoneConvex` directly.

## Breaking changes

Code that dispatched on `::ZeroRateCurve` or accessed `zrc.rates` / `zrc.tenors` / `zrc.spline` will break.

Survey of impact:
- **AU v5.6 internals** dispatched on `::ZRC`. AU v5.7 (in [#139](https://github.com/JuliaActuary/ActuaryUtilities.jl/pull/139)) removed those as part of unrelated unification work, so AU master is fine.
- **AU 5.6.4 (registered)** still has the old dispatches and will not load against FM 5.6.0. AU 5.7 must release before this lands.
- **AU `test/runtests.jl`** had one `zrc.tenors` reference; the paired AU PR updates it to use a local `tenors` variable.
- **No other ecosystem consumers** were found that dispatch on or field-access ZRC.

## Other changes

- Removed `ActuaryUtilities` from `test/Project.toml`. The only file using it (`test/ActuaryUtilities.jl`) is already commented out in `runtests.jl`, and keeping the dep was forcing the registered (incompatible) AU 5.6.4 to precompile at test-setup time.
- Updated `docs/src/index.md` and `docs/src/interpolation.md` to describe ZRC as a factory function.

## Test plan

- [x] All FM tests pass locally — including the 38-test `ZeroRateCurve` testset, which exercises the constructor and the full `AbstractYieldModel` interface (no migration needed; the tests never dispatched on the struct or accessed fields).
- [x] All AU tests pass locally against this FM (after the paired AU PR's one-line `zrc.tenors` migration).
- [ ] CI green.

Version bumped to **5.6.0** — minor (breaking for type-dispatch / field-access; non-breaking for abstract interface consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)