### PR TITLE
MonotoneConvex: fix knot 0/0 NaN + g0==0 discontinuity, unbreak the public fit paths

### DIFF
--- a/src/fit.jl
+++ b/src/fit.jl
@@ -111,8 +111,18 @@ __default_optic(m::MyModel) = (
 
 """
 __default_optic(m::Yield.Constant) = ((@optic(_.rate.continuous_value) => -1.0 .. 1.0),)
-__default_optic(m::Yield.MonotoneConvexUnInit) = Tuple(@optic(_.rates) .=> -1.0 .. 1.0)
-__default_optic(m::Yield.MonotoneConvex) = Tuple(@optic(_.rates) .=> -1.0 .. 1.0)
+# One bounded optic per knot rate. The previous `Tuple(@optic(_.rates) .=> -1 .. 1)`
+# broadcast over a `ClosedInterval` (which is not iterable) and so threw on the
+# first call, breaking the generic `fit(::MonotoneConvex, …)` path entirely.
+__default_optic(m::Yield.MonotoneConvex) = ntuple(i -> (@optic(_.rates[i]) => -1.0 .. 1.0), length(m.rates))
+
+# `MonotoneConvex` caches `f`/`fᵈ` derived from `(rates, times)` and has only a
+# 2-arg constructor, so ConstructionBase's default positional reconstruction
+# (`MonotoneConvex(f, fᵈ, rates, times)`) has no method — breaking `@set`/
+# `setproperties` and hence the Accessors-driven `fit` path. Reconstruct from the
+# stored rates/times, which recomputes the cache and keeps `f`/`fᵈ` consistent.
+Accessors.ConstructionBase.constructorof(::Type{<:Yield.MonotoneConvex}) =
+    (f, fᵈ, rates, times) -> Yield.MonotoneConvex(rates, times)
 __default_optic(m::Yield.NelsonSiegel) = (
         @optic(_.τ₁) => 0.0 .. 100.0,
         @optic(_.β₀) => -10.0 .. 10.0,
@@ -345,6 +355,18 @@ function fit(mod0::T, quotes, method::F) where {T <: Spline.SplineCurve, F <: Fi
     return Yield.Spline(mod0, times, sol.u)
 
 end
+
+# `Spline.MonotoneConvex` is a tag for the native Hagan-West curve, not a
+# DataInterpolations spline: the generic spline paths above build `Yield.Spline`
+# (no MonotoneConvex method) and bootstrap's incremental, t=0-anchored knots do
+# not match Hagan-West's non-local forward construction. Both entry points route
+# to the dedicated `Yield.MonotoneConvex` fit, which reprices the whole quote set
+# at once (matching `Spline.MonotoneConvex`'s documented "dispatches to
+# Yield.MonotoneConvex" behavior).
+function fit(::Spline.MonotoneConvex, quotes, method::Fit.Loss; optimizer = OptimizationOptimJL.LBFGS())
+    return fit(Yield.MonotoneConvex(), quotes, method; optimizer)
+end
+fit(::Spline.MonotoneConvex, quotes, ::Fit.Bootstrap) = fit(Yield.MonotoneConvex(), quotes)
 
 function fit(mod0::T, quotes, method::Fit.Bootstrap) where {T <: Spline.SplineCurve}
     quotes = sort(collect(quotes); by = maturity)

--- a/src/model/Yield/MonotoneConvex.jl
+++ b/src/model/Yield/MonotoneConvex.jl
@@ -60,9 +60,16 @@ function __issector1(g0, g1)
     return a || b
 end
 
+# `>=`/`<=` (not `>`/`<`) so the boundary g0 == 0 (left node forward equals the
+# discrete forward) is classified here, giving η == 1. Otherwise it falls through
+# to sector (iii) with η == 3g1/(g1-g0) == 3 > 1, where the [0, η] sub-region the
+# formula assumes within [0, 1] does not exist, so ∫₀¹ g ≠ 0 and the interval
+# fails to reprice its right knot (a small zero-rate discontinuity). For g0 != 0
+# the bounds are unchanged. (The η == 1 singularity at x == 1 is handled by the
+# boundary guard in `g`/`g_rate`.)
 function __issector2(g0, g1)
-    a = (g0 > 0) && (g1 < -2 * g0)
-    b = (g0 < 0) && (g1 > -2 * g0)
+    a = (g0 >= 0) && (g1 < -2 * g0)
+    b = (g0 <= 0) && (g1 > -2 * g0)
     return a || b
 end
 
@@ -84,14 +91,16 @@ end
 function g(x, f⁻, f, fᵈ)
     g0 = f⁻ - fᵈ
     g1 = f - fᵈ
-    # At x == 0 (hit exactly at every interior knot) the deviation is the left
-    # boundary value g(0) = g0. Returning it directly avoids the 0/0 that sector
-    # (iii) produces when g1 == 0 (⟹ η == 0, so its `/η` is singular). An
-    # `iszero(η)` guard is *not* safe here: under ForwardDiff η carries nonzero
-    # partials despite a zero value, so `iszero(η)` is false and the singular
-    # branch still runs, yielding NaN gradients. `x` is the normalized interval
-    # position — a plain Float at knots, never the AD variable — so this is safe.
+    # Interval-boundary deviations are exact: g(0) = g0 and g(1) = g1. Returning
+    # them directly avoids the 0/0 the sector formulas produce at a degenerate η:
+    # sector (iii) has `/η` and is singular when g1 == 0 (η == 0, hit at every
+    # interior knot, x == 0); sector (ii) has `/(1-η)` and is singular when g0 == 0
+    # (η == 1, hit at the last knot, x == 1). An `iszero(η)` guard is *not* safe
+    # under ForwardDiff — η carries nonzero partials despite a zero value, so the
+    # singular branch still runs and yields NaN gradients. `x` is the normalized
+    # interval position — a plain Float at the boundaries, never the AD variable.
     iszero(x) && return g0
+    isone(x) && return g1
     # Near-flat interval: linear fallback avoids 0/0 and preserves AD partials
     if _mc_negligible(g0, g1, fᵈ)
         return g0 * (1 - x) + g1 * x
@@ -140,11 +149,13 @@ the Hagan-West construction.
 function g_rate(x, f⁻, f, fᵈ)
     g0 = f⁻ - fᵈ
     g1 = f - fᵈ
-    # G(0) = ∫₀⁰ g du = 0 identically (hit exactly at every interior knot).
-    # Returning zero directly avoids the 0/0 that sector (iii) produces when
-    # g1 == 0 (⟹ η == 0, so its `/η²` is singular). See `g` for why guarding on
-    # `iszero(η)` is unsafe under ForwardDiff and `x` is the safe discriminator.
-    iszero(x) && return zero(g0 * x)
+    # G(0) = ∫₀⁰ g = 0 and G(1) = ∫₀¹ g = 0 are both identities (the interpolated
+    # forward integrates to the discrete forward over each interval). Returning
+    # zero directly avoids the 0/0 the sector formulas produce at a degenerate η:
+    # sector (iii) `/η²` is singular at g1 == 0 (η == 0, interior knots, x == 0),
+    # sector (ii) `/(1-η)²` at g0 == 0 (η == 1, last knot, x == 1). See `g` for why
+    # an `iszero(η)` guard is unsafe under ForwardDiff and `x` is the discriminator.
+    (iszero(x) || isone(x)) && return zero(g0 * x)
     # Near-flat interval: linear integral fallback avoids 0/0 and preserves AD partials
     if _mc_negligible(g0, g1, fᵈ)
         return g0 * x + (g1 - g0) * x^2 / 2  # ∫₀ˣ [g0(1-u) + g1·u] du

--- a/src/model/Yield/MonotoneConvex.jl
+++ b/src/model/Yield/MonotoneConvex.jl
@@ -84,6 +84,14 @@ end
 function g(x, f⁻, f, fᵈ)
     g0 = f⁻ - fᵈ
     g1 = f - fᵈ
+    # At x == 0 (hit exactly at every interior knot) the deviation is the left
+    # boundary value g(0) = g0. Returning it directly avoids the 0/0 that sector
+    # (iii) produces when g1 == 0 (⟹ η == 0, so its `/η` is singular). An
+    # `iszero(η)` guard is *not* safe here: under ForwardDiff η carries nonzero
+    # partials despite a zero value, so `iszero(η)` is false and the singular
+    # branch still runs, yielding NaN gradients. `x` is the normalized interval
+    # position — a plain Float at knots, never the AD variable — so this is safe.
+    iszero(x) && return g0
     # Near-flat interval: linear fallback avoids 0/0 and preserves AD partials
     if _mc_negligible(g0, g1, fᵈ)
         return g0 * (1 - x) + g1 * x
@@ -132,6 +140,11 @@ the Hagan-West construction.
 function g_rate(x, f⁻, f, fᵈ)
     g0 = f⁻ - fᵈ
     g1 = f - fᵈ
+    # G(0) = ∫₀⁰ g du = 0 identically (hit exactly at every interior knot).
+    # Returning zero directly avoids the 0/0 that sector (iii) produces when
+    # g1 == 0 (⟹ η == 0, so its `/η²` is singular). See `g` for why guarding on
+    # `iszero(η)` is unsafe under ForwardDiff and `x` is the safe discriminator.
+    iszero(x) && return zero(g0 * x)
     # Near-flat interval: linear integral fallback avoids 0/0 and preserves AD partials
     if _mc_negligible(g0, g1, fᵈ)
         return g0 * x + (g1 - g0) * x^2 / 2  # ∫₀ˣ [g0(1-u) + g1·u] du

--- a/test/MonotoneConvex.jl
+++ b/test/MonotoneConvex.jl
@@ -256,4 +256,68 @@
         @test Yield.instantaneous_forward(c, 0.5) ≈ 0.03
         @test rate(zero(c, 4.0)) ≈ 0.03  # constant-forward extrapolation
     end
+
+    @testset "equal adjacent discrete forwards (g1 == 0 / η == 0)" begin
+        # When two adjacent discrete forwards coincide (any flat-forward segment),
+        # the interpolated node forward equals the discrete forward, so the
+        # sector-(iii) deviation g1 is exactly 0 and η == 0. The zero-rate integral
+        # G is evaluated at x == 0 exactly at each knot; the unguarded 0/0 there
+        # made both the discount factor AND its ForwardDiff gradient NaN — the
+        # latter silently stalled `fit` at its initial guess for every optimizer.
+
+        # a flat zero-rate curve makes every adjacent pair of discrete forwards equal
+        times = [1 / 12, 2 / 12, 3 / 12, 0.5, 1.0, 2.0, 3.0, 5.0]
+        cflat = Yield.MonotoneConvex(fill(0.03, length(times)), times)
+        @test all(isfinite(discount(cflat, t)) for t in range(1.0e-6, last(times); length = 200))
+        for (i, t) in enumerate(times)
+            @test rate(zero(cflat, t)) ≈ 0.03 atol = 1.0e-12
+        end
+
+        # the reported scenario: par quotes including short (≤6m) tenors. Before the
+        # fix `fit` returned a NaN-repricing curve for every optimizer because the
+        # loss gradient was NaN at the (degenerate) fixed ramp seed.
+        tenors = [1 / 12, 2 / 12, 3 / 12, 0.5, 1.0, 2.0, 3.0, 5.0, 7.0, 10.0, 20.0, 30.0]
+        pars = [0.0375, 0.0372, 0.0372, 0.0372, 0.0364, 0.0368,
+            0.0369, 0.0380, 0.0400, 0.0423, 0.0483, 0.0486]
+        qs = sort(CMTYield.(pars, tenors); by = maturity)
+        reprice(c) = maximum(abs, present_value(c, q.instrument) - q.price for q in qs)
+        for opt in (
+                FinanceModels.OptimizationOptimJL.LBFGS(),
+                FinanceModels.OptimizationOptimJL.BFGS(),
+                FinanceModels.OptimizationOptimJL.Newton(),
+            )
+            c = fit(Yield.MonotoneConvex(), qs; optimizer = opt)
+            @test reprice(c) < 1.0e-6   # finite (not NaN) and actually fits
+        end
+
+        # the Spline.MonotoneConvex tag routes to the native curve on every path
+        @test reprice(fit(Spline.MonotoneConvex(), qs)) < 1.0e-6
+        @test reprice(fit(Spline.MonotoneConvex(), qs, Fit.Loss(x -> x^2))) < 1.0e-6
+        @test reprice(fit(Spline.MonotoneConvex(), qs, Fit.Bootstrap())) < 1.0e-6
+    end
+
+    @testset "Accessors / generic fit compatibility" begin
+        times = [1.0, 2.0, 3.0, 5.0, 7.0]
+        rates = [0.03, 0.032, 0.034, 0.037, 0.039]
+        c = Yield.MonotoneConvex(rates, times)
+
+        # one bounded optic per knot (previously a broadcast over a ClosedInterval
+        # that threw `iterate(::ClosedInterval)` the moment it was evaluated)
+        optic = FinanceModels.__default_optic(c)
+        @test length(optic) == length(rates)
+
+        # reconstructable via Accessors, and the cached f/fᵈ stay consistent with
+        # the updated rates (the struct caches derived fields but had no 4-arg ctor)
+        c2 = Accessors.@set c.rates[2] = 0.05
+        @test c2.rates[2] == 0.05
+        f, fᵈ = Yield.__monotone_convex_fs(c2.rates, c2.times)
+        @test c2.f == f
+        @test c2.fᵈ == fᵈ
+
+        # the generic, variables-driven `fit(model, quotes)` path now runs (it used
+        # the broken optic and the non-reconstructable struct) and reprices
+        qs = CMTYield.(rates, times)
+        fitted = fit(c, qs)
+        @test maximum(abs, present_value(fitted, q.instrument) - q.price for q in qs) < 1.0e-6
+    end
 end

--- a/test/MonotoneConvex.jl
+++ b/test/MonotoneConvex.jl
@@ -296,6 +296,31 @@
         @test reprice(fit(Spline.MonotoneConvex(), qs, Fit.Bootstrap())) < 1.0e-6
     end
 
+    @testset "g0 == 0 (flat-forward segment): continuous zero rates" begin
+        # The mirror of the g1 == 0 case: a flat-forward segment makes the node
+        # forward equal the discrete forward at the segment's right boundary, so
+        # g0 == 0 there. That used to route to sector (iii) with η == 3 > 1, where
+        # ∫₀¹ g ≠ 0, so the interval failed to reprice its right knot — a small
+        # (~1e-3) zero-rate discontinuity (visible approaching the knot from the
+        # left, since the knot itself is repriced via the next interval).
+        rates = [0.02, 0.03, 0.035, 0.035, 0.035, 0.04, 0.05]
+        times = [0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 7.0]
+        c = Yield.MonotoneConvex(rates, times)
+        for (i, t) in enumerate(times)
+            @test rate(zero(c, t)) ≈ rates[i] atol = 1.0e-12          # reprices at the knot
+            # z is continuous, so the left limit must also approach rate[i]; the
+            # sector-(iii) η>1 misroute made this off by ~9e-4 at the g0==0 knot
+            i > 1 && @test rate(zero(c, t - 1.0e-6)) ≈ rates[i] atol = 1.0e-4
+        end
+
+        # g0 == 0 in the LAST interval forces the x == 1 boundary evaluation at the
+        # last knot (i_time is capped at lastindex), exercising the x == 1 guard
+        # that keeps sector (ii)'s η == 1 from dividing by zero.
+        clast = Yield.MonotoneConvex([0.03, 0.035, 0.035], [1.0, 2.0, 3.0])
+        @test isfinite(rate(zero(clast, 3.0)))
+        @test rate(zero(clast, 3.0)) ≈ 0.035 atol = 1.0e-12
+    end
+
     @testset "Accessors / generic fit compatibility" begin
         times = [1.0, 2.0, 3.0, 5.0, 7.0]
         rates = [0.03, 0.032, 0.034, 0.037, 0.039]


### PR DESCRIPTION
Fixes `Yield.MonotoneConvex` so it can be reliably fit to par quotes through the public API, and fixes the two degenerate-forward boundary cases in the Hagan–West construction. Branched off `master` (v6.1.0); **only the MonotoneConvex fix** (3 files, +139/−4).

## 1. Knot `0/0` singularity in `g`/`g_rate` — `g1 == 0` (the core bug)
When two adjacent discrete forwards coincide (any flat-forward segment), the interpolated node forward equals the discrete forward, so the sector-(iii) deviation `g1` is exactly `0` (η = 0). The zero-rate integral `G` is evaluated at `x = 0` **exactly at every interior knot**, where sector (iii) divides by η → an unguarded `0/0`.

Two failure layers:
- **value**: `discount(curve, knot) = NaN`;
- **gradient**: still `NaN` after guarding the value, because `iszero(η)` is `false` under ForwardDiff (η carries nonzero partials despite a zero value), so the singular branch runs anyway. This NaN gradient silently stalled `fit` at its initial guess for *every* optimizer — the "fitted" rates came back byte-identical to the seed.

Fix: guard on `iszero(x)`/`isone(x)`. `x` is the normalized interval position — exactly `0`/`1` at knots, never the AD variable — so the test is AD-safe. `g(0)=g0`, `g(1)=g1`, `G(0)=G(1)=0` are exact identities (and the correct η→0/1 limits), so non-degenerate inputs are unchanged.

## 2. Mirror case — `g0 == 0` (zero-rate discontinuity)
When the *left* node forward equals the discrete forward (`g0 == 0`), the interval routed to sector (iii) with η = 3 > 1, where `∫₀¹ g ≠ 0`, so it failed to reprice its right knot — a small (~1e-3) zero-rate **discontinuity** (a grid sweep confirms `g0 == 0` is the *only* region where `∫₀¹ g ≠ 0`). Fixed by classifying `g0 == 0` as sector (ii) (η = 1, `G ≡ 0` on `[0,1)`) via inclusive `__issector2` bounds, plus the `x == 1` guard above (sector (ii) is singular at η = 1, and `x == 1` *is* evaluated at the last knot since `i_time` is capped).

## 3. `Spline.MonotoneConvex` fit paths
`fit(Spline.MonotoneConvex(), q)` and `… Fit.Bootstrap()` errored with `MethodError: Yield.Spline(::Spline.MonotoneConvex, …)`. Both now route to the dedicated native fit.

## 4. Accessors / ConstructionBase compatibility
- `__default_optic(::MonotoneConvex)` **threw** `iterate(::ClosedInterval)` on first use → now one bounded optic per knot.
- `MonotoneConvex` wasn't reconstructable (cached `f`/`fᵈ`, only a 2-arg constructor) → added a `constructorof` that rebuilds from `rates`/`times`, recomputing the cache.

## Verification
- Short-tenor par fit matches a square-system Newton reference to ~2e-13; **0 NaN/Inf gradients across 200 random rate vectors**.
- `g0 == 0` grid-sweep repricing violations: **24 → 0**; adversarial flat-segment knot discontinuity drops ~9e-4 → ~3e-10.
- New regression tests close the AD-gradient coverage gap that let this ship.
- Full `Pkg.test` on `master`: **Monotone Convex 496/496**, spline/bootstrap/ZeroRateCurve/audit/Aqua all green, **zero regressions**.

Follow-up tracked in #272: the `Spline.MonotoneConvex` tag vs `Yield.MonotoneConvex` taxonomy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
