### PR TITLE
refactor(yield): consolidate discount-from-zero implementations

### DIFF
--- a/src/model/Model.jl
+++ b/src/model/Model.jl
@@ -35,8 +35,8 @@ pv(m, a) # ≈ 0.05410094201902403
 ```
 """
 function FinanceCore.present_value(model, c::FinanceCore.AbstractContract, cur_time = 0.0)
-    p = Projection(c, model, CashflowProjection())
-    xf = p |> Filter(cf -> cf.time >= cur_time) |> Map(cf -> FinanceCore.discount(model, cur_time, cf.time) * cf.amount)
-    # init: an empty fold (e.g. valuing past maturity) is worth 0, not an error
-    return foldxl(+, xf; init = 0.0)
+    # Wrap the bare contract in the default cashflow projection and reuse the single
+    # discounting fold defined for `Projection` (see Projection.jl) rather than
+    # duplicating it here.
+    return present_value(model, Projection(c, model, CashflowProjection()), cur_time)
 end

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -11,38 +11,13 @@ export discount, zero, forward, par, pv, instantaneous_forward
 
 abstract type AbstractYieldModel <: AbstractModel end
 
-"""
-    AbstractZeroCurve <: AbstractYieldModel
-
-Supertype for *zero-rate-native* yield curves — models whose primitive is the
-continuous zero rate `zero(curve, t)`. The discount factor is derived from it once,
-here:
-
-    discount(curve, t) = discount(zero(curve, t), t)     # with discount(curve, 0) = 1
-
-so a concrete subtype need only define [`Base.zero`](@ref); it inherits `discount`
-(and through it `forward`, `accumulation`, and the callable `curve(t)`). This is the
-curve-side counterpart of the discount-native models (`SmithWilson`, the short-rate
-models, …) which instead define `discount` and inherit the generic
-`zero(curve, t) = -log(discount)/t`.
-
-A subtype may still provide its own `discount` as a fast path (e.g. [`Constant`](@ref),
-`Yield.Spline`); the more specific method wins by ordinary dispatch.
-
-!!! warning
-    Every subtype MUST define `Base.zero`. Otherwise this method and the generic
-    `zero`-from-`discount` fallback call each other and recurse.
-"""
-abstract type AbstractZeroCurve <: AbstractYieldModel end
-
-# The single home for "discount factor derived from the zero rate", shared by every
-# zero-native curve (CompositeYield, ScaledYield, the yield shifts, NelsonSiegel(Svensson),
-# CairnsPritchard, MonotoneConvex, …). `one(float(t))` keeps the t=0 result type-stable
-# across Int, Float, and ForwardDiff.Dual time arguments alike.
-function FinanceCore.discount(c::AbstractZeroCurve, t)
-    iszero(t) && return one(float(t))
-    return discount(Base.zero(c, t), t)
-end
+# Discount factor derived from the continuous zero rate — the single home for this logic,
+# shared by every zero-native curve through the one-line `discount` stubs at each curve
+# definition (CompositeYield, ScaledYield, the yield shifts, NelsonSiegel(Svensson),
+# CairnsPritchard, MonotoneConvex). Curves with a cheaper direct formula (Constant,
+# Yield.Spline) define their own `discount` instead. `one(float(t))` keeps the t=0 result
+# type-stable across Int, Float, and ForwardDiff.Dual time arguments alike.
+_discount_from_zero(c, t) = iszero(t) ? one(float(t)) : discount(Base.zero(c, t), t)
 
 # Generic callable fallback: `curve(t) ≡ discount(curve, t)`. Covers every
 # AbstractYieldModel subtype (Constant, Spline, CompositeYield, ScaledYield,
@@ -58,7 +33,7 @@ A yield curve representing a flat term structure. `rate` can be a [`Rate`](@ref)
 
 If [`fit`](@ref FinanceModels.fit-Union{Tuple{F}, Tuple{Any, Any}, Tuple{Any, Any, F}} where F<:FinanceModels.Fit.Loss)ing with the default FinanceModels.jl settings, the solver will attempt to fit a discount rate with the range of: `-1.0 .. 1.0`
 """
-struct Constant{R} <: AbstractZeroCurve
+struct Constant{R} <: AbstractYieldModel
     rate::R
 end
 
@@ -76,7 +51,7 @@ FinanceCore.discount(c::Constant, t) = FinanceCore.discount(c.rate, t)
 # `Constant` stay in zero-rate space (see `CompositeYield`/`ScaledYield`).
 Base.zero(c::Constant, t) = convert(Continuous(), c.rate)
 
-struct Spline{U} <: AbstractZeroCurve
+struct Spline{U} <: AbstractYieldModel
     fn::U # here, fn is a map from time to instantaneous zero rate
 end
 
@@ -321,7 +296,7 @@ c_y = fit(Spline.Linear(),q_y,Fit.Bootstrap())
 @test !(discount(c_rf+c_s,20) ≈ discount(c_y,20))
 ```
 """
-struct CompositeYield{T, U, V} <: AbstractZeroCurve
+struct CompositeYield{T, U, V} <: AbstractYieldModel
     r1::T
     r2::U
     op::V
@@ -337,7 +312,7 @@ function Base.zero(rc::CompositeYield, time)
     z2 = FinanceCore.rate(Base.zero(rc.r2, time))
     return Continuous(rc.op(z1, z2))
 end
-# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).
+FinanceCore.discount(rc::CompositeYield, time) = _discount_from_zero(rc, time)
 
 # ─── Yield shifts (TenorShift, ProjectedShift) ────────────────────────────
 
@@ -359,7 +334,7 @@ Two concrete subtypes:
 Both subtypes implement the standard `AbstractYieldModel` interface (`zero`,
 `discount`, `forward`, `pv`).
 """
-abstract type AbstractYieldShift <: AbstractZeroCurve end
+abstract type AbstractYieldShift <: AbstractYieldModel end
 
 """
     TenorShift(base, rule)
@@ -480,7 +455,7 @@ function Base.zero(s::ProjectedShift, t)
     z = Base.zero(s.base, t)
     return convert(Continuous(), s.rule(s.time, z, t)::FinanceCore.Rate)
 end
-# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).
+FinanceCore.discount(s::AbstractYieldShift, t) = _discount_from_zero(s, t)
 
 # Deprecated alias for the previous name. Slated for removal one minor release after introduction.
 Base.@deprecate_binding TransformedYield TenorShift
@@ -493,18 +468,18 @@ A yield model that scales the continuous zero rates of `curve` by a `Real` scala
 Created via `curve * scalar` or `curve / scalar`. For example, `curve * 0.79` scales
 all continuous zero rates by 0.79, which is useful for after-tax yield calculations.
 """
-struct ScaledYield{T<:AbstractYieldModel, S<:Real} <: AbstractZeroCurve
+struct ScaledYield{T<:AbstractYieldModel, S<:Real} <: AbstractYieldModel
     curve::T
     factor::S
 end
 
 # Scaling is a multiply in continuous-zero-rate space, so derive `zero` directly; the
-# discount factor (a single `exp`, no discount → log round-trip) is inherited from
-# `AbstractZeroCurve`.
+# discount factor (a single `exp`, no discount → log round-trip) follows from it.
 function Base.zero(sy::ScaledYield, time)
     z = FinanceCore.rate(Base.zero(sy.curve, time))
     return Continuous(z * sy.factor)
 end
+FinanceCore.discount(sy::ScaledYield, time) = _discount_from_zero(sy, time)
 
 """
     ForwardStarting(curve,forwardstart)

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -15,10 +15,14 @@ abstract type AbstractYieldModel <: AbstractModel end
 # shared by every zero-native curve through the one-line `discount` stubs at each curve
 # definition (CompositeYield, ScaledYield, the yield shifts, NelsonSiegel(Svensson),
 # CairnsPritchard, MonotoneConvex). Curves with a cheaper direct formula (Constant,
-# Yield.Spline) define their own `discount` instead. The affected curves all define a
-# finite zero rate at t=0, so delegating to the rate-level `discount` also preserves the
-# promoted numeric type carried by the curve parameters.
-_discount_from_zero(c, t) = discount(Base.zero(c, t), t)
+# Yield.Spline) define their own `discount` instead. Leaf curves provide a finite zero
+# rate at t=0, but wrappers may sit over discount-native curves whose generic `zero`
+# has a removable 0/0 singularity there. Forming `one(df)` preserves the promoted
+# curve/time numeric type while enforcing the discount-factor identity DF(0) = 1.
+function _discount_from_zero(c, t)
+    df = discount(Base.zero(c, t), t)
+    return iszero(t) ? one(df) : df
+end
 
 # Generic callable fallback: `curve(t) ≡ discount(curve, t)`. Covers every
 # AbstractYieldModel subtype (Constant, Spline, CompositeYield, ScaledYield,

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -11,11 +11,43 @@ export discount, zero, forward, par, pv, instantaneous_forward
 
 abstract type AbstractYieldModel <: AbstractModel end
 
+"""
+    AbstractZeroCurve <: AbstractYieldModel
+
+Supertype for *zero-rate-native* yield curves — models whose primitive is the
+continuous zero rate `zero(curve, t)`. The discount factor is derived from it once,
+here:
+
+    discount(curve, t) = discount(zero(curve, t), t)     # with discount(curve, 0) = 1
+
+so a concrete subtype need only define [`Base.zero`](@ref); it inherits `discount`
+(and through it `forward`, `accumulation`, and the callable `curve(t)`). This is the
+curve-side counterpart of the discount-native models (`SmithWilson`, the short-rate
+models, …) which instead define `discount` and inherit the generic
+`zero(curve, t) = -log(discount)/t`.
+
+A subtype may still provide its own `discount` as a fast path (e.g. [`Constant`](@ref),
+`Yield.Spline`); the more specific method wins by ordinary dispatch.
+
+!!! warning
+    Every subtype MUST define `Base.zero`. Otherwise this method and the generic
+    `zero`-from-`discount` fallback call each other and recurse.
+"""
+abstract type AbstractZeroCurve <: AbstractYieldModel end
+
+# The single home for "discount factor derived from the zero rate", shared by every
+# zero-native curve (CompositeYield, ScaledYield, the yield shifts, NelsonSiegel(Svensson),
+# CairnsPritchard, MonotoneConvex, …). `one(float(t))` keeps the t=0 result type-stable
+# across Int, Float, and ForwardDiff.Dual time arguments alike.
+function FinanceCore.discount(c::AbstractZeroCurve, t)
+    iszero(t) && return one(float(t))
+    return discount(Base.zero(c, t), t)
+end
+
 # Generic callable fallback: `curve(t) ≡ discount(curve, t)`. Covers every
-# AbstractYieldModel subtype (Constant, CompositeYield, ScaledYield,
-# TenorShift, ProjectedShift, NelsonSiegel, etc.) that does not define its
-# own callable. More-specific callables (ZeroRateCurve, Spline,
-# MonotoneConvex) take precedence by ordinary multiple dispatch.
+# AbstractYieldModel subtype (Constant, Spline, CompositeYield, ScaledYield,
+# TenorShift, ProjectedShift, NelsonSiegel, MonotoneConvex, ZeroRateCurve, …);
+# each one routes through its own `discount`, so no per-type callable is needed.
 (yc::AbstractYieldModel)(t) = FinanceCore.discount(yc, t)
 
 """
@@ -26,7 +58,7 @@ A yield curve representing a flat term structure. `rate` can be a [`Rate`](@ref)
 
 If [`fit`](@ref FinanceModels.fit-Union{Tuple{F}, Tuple{Any, Any}, Tuple{Any, Any, F}} where F<:FinanceModels.Fit.Loss)ing with the default FinanceModels.jl settings, the solver will attempt to fit a discount rate with the range of: `-1.0 .. 1.0`
 """
-struct Constant{R} <: AbstractYieldModel
+struct Constant{R} <: AbstractZeroCurve
     rate::R
 end
 
@@ -44,14 +76,12 @@ FinanceCore.discount(c::Constant, t) = FinanceCore.discount(c.rate, t)
 # `Constant` stay in zero-rate space (see `CompositeYield`/`ScaledYield`).
 Base.zero(c::Constant, t) = convert(Continuous(), c.rate)
 
-struct Spline{U} <: AbstractYieldModel
+struct Spline{U} <: AbstractZeroCurve
     fn::U # here, fn is a map from time to instantaneous zero rate
 end
 
-function (c::Spline)(time)
-    return exp(-c.fn(time) * time)
-end
-
+# `discount`/`zero` below are the interface; the callable `(c::Spline)(t)` comes from
+# the generic `AbstractYieldModel` fallback, which routes to this same `discount`.
 function FinanceCore.discount(c::Spline, time)
     z = c.fn(time)
     return exp(-z * time)
@@ -102,9 +132,6 @@ include("Yield/SmithWilson.jl")
 include("Yield/NelsonSiegelSvensson.jl")
 include("Yield/CairnsPritchard.jl")
 include("Yield/MonotoneConvex.jl")
-
-# callable interface for MonotoneConvex (matches Spline and ZeroRateCurve)
-(mc::MonotoneConvex)(t) = FinanceCore.discount(mc, t)
 
 """
     build_model(spline, tenors, rates)
@@ -294,7 +321,7 @@ c_y = fit(Spline.Linear(),q_y,Fit.Bootstrap())
 @test !(discount(c_rf+c_s,20) ≈ discount(c_y,20))
 ```
 """
-struct CompositeYield{T, U, V} <: AbstractYieldModel
+struct CompositeYield{T, U, V} <: AbstractZeroCurve
     r1::T
     r2::U
     op::V
@@ -310,11 +337,7 @@ function Base.zero(rc::CompositeYield, time)
     z2 = FinanceCore.rate(Base.zero(rc.r2, time))
     return Continuous(rc.op(z1, z2))
 end
-
-function FinanceCore.discount(rc::CompositeYield, time)
-    iszero(time) && return one(time)
-    return discount(Base.zero(rc, time), time)
-end
+# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).
 
 # ─── Yield shifts (TenorShift, ProjectedShift) ────────────────────────────
 
@@ -336,7 +359,7 @@ Two concrete subtypes:
 Both subtypes implement the standard `AbstractYieldModel` interface (`zero`,
 `discount`, `forward`, `pv`).
 """
-abstract type AbstractYieldShift <: AbstractYieldModel end
+abstract type AbstractYieldShift <: AbstractZeroCurve end
 
 """
     TenorShift(base, rule)
@@ -457,12 +480,7 @@ function Base.zero(s::ProjectedShift, t)
     z = Base.zero(s.base, t)
     return convert(Continuous(), s.rule(s.time, z, t)::FinanceCore.Rate)
 end
-
-function FinanceCore.discount(s::AbstractYieldShift, t)
-    iszero(t) && return one(t)
-    z = Base.zero(s, t)
-    return exp(-z.continuous_value * t)
-end
+# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).
 
 # Deprecated alias for the previous name. Slated for removal one minor release after introduction.
 Base.@deprecate_binding TransformedYield TenorShift
@@ -475,21 +493,17 @@ A yield model that scales the continuous zero rates of `curve` by a `Real` scala
 Created via `curve * scalar` or `curve / scalar`. For example, `curve * 0.79` scales
 all continuous zero rates by 0.79, which is useful for after-tax yield calculations.
 """
-struct ScaledYield{T<:AbstractYieldModel, S<:Real} <: AbstractYieldModel
+struct ScaledYield{T<:AbstractYieldModel, S<:Real} <: AbstractZeroCurve
     curve::T
     factor::S
 end
 
-# Scaling is a multiply in continuous-zero-rate space, so derive `zero` directly and
-# form the discount factor with a single `exp` (no discount → log round-trip).
+# Scaling is a multiply in continuous-zero-rate space, so derive `zero` directly; the
+# discount factor (a single `exp`, no discount → log round-trip) is inherited from
+# `AbstractZeroCurve`.
 function Base.zero(sy::ScaledYield, time)
     z = FinanceCore.rate(Base.zero(sy.curve, time))
     return Continuous(z * sy.factor)
-end
-
-function FinanceCore.discount(sy::ScaledYield, time)
-    iszero(time) && return one(sy.factor)
-    return discount(Base.zero(sy, time), time)
 end
 
 """

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -15,9 +15,10 @@ abstract type AbstractYieldModel <: AbstractModel end
 # shared by every zero-native curve through the one-line `discount` stubs at each curve
 # definition (CompositeYield, ScaledYield, the yield shifts, NelsonSiegel(Svensson),
 # CairnsPritchard, MonotoneConvex). Curves with a cheaper direct formula (Constant,
-# Yield.Spline) define their own `discount` instead. `one(float(t))` keeps the t=0 result
-# type-stable across Int, Float, and ForwardDiff.Dual time arguments alike.
-_discount_from_zero(c, t) = iszero(t) ? one(float(t)) : discount(Base.zero(c, t), t)
+# Yield.Spline) define their own `discount` instead. The affected curves all define a
+# finite zero rate at t=0, so delegating to the rate-level `discount` also preserves the
+# promoted numeric type carried by the curve parameters.
+_discount_from_zero(c, t) = discount(Base.zero(c, t), t)
 
 # Generic callable fallback: `curve(t) ≡ discount(curve, t)`. Covers every
 # AbstractYieldModel subtype (Constant, Spline, CompositeYield, ScaledYield,

--- a/src/model/Yield/CairnsPritchard.jl
+++ b/src/model/Yield/CairnsPritchard.jl
@@ -22,7 +22,7 @@ See also [`CairnsPritchardExtended`](@ref) for a 3-component variant.
 # References
 - Cairns, A.J.G. (1998). "Descriptive Bond-Yield and Forward-Rate Models for the British Government Securities Market". British Actuarial Journal, 4(2), 265-321.
 """
-struct CairnsPritchard{T} <: AbstractZeroCurve
+struct CairnsPritchard{T} <: AbstractYieldModel
     c₁::T
     c₂::T
     b₀::T
@@ -49,7 +49,7 @@ function Base.zero(cp::CairnsPritchard, t)
     # At t=0 the formula is already well-defined: exp(0) = 1, so z(0) = b₀ + b₁ + b₂
     return Continuous(cp.b₀ + cp.b₁ * exp(-cp.c₁ * t) + cp.b₂ * exp(-cp.c₂ * t))
 end
-# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).
+FinanceCore.discount(cp::CairnsPritchard, t) = _discount_from_zero(cp, t)
 
 """
     CairnsPritchardExtended(c₁, c₂, c₃, b₀, b₁, b₂, b₃)
@@ -76,7 +76,7 @@ See also [`CairnsPritchard`](@ref) for a 2-component variant.
 # References
 - Cairns, A.J.G. (1998). "Descriptive Bond-Yield and Forward-Rate Models for the British Government Securities Market". British Actuarial Journal, 4(2), 265-321.
 """
-struct CairnsPritchardExtended{T} <: AbstractZeroCurve
+struct CairnsPritchardExtended{T} <: AbstractYieldModel
     c₁::T
     c₂::T
     c₃::T
@@ -105,4 +105,4 @@ function Base.zero(cp::CairnsPritchardExtended, t)
     # At t=0 the formula is already well-defined: exp(0) = 1, so z(0) = b₀ + b₁ + b₂ + b₃
     return Continuous(cp.b₀ + cp.b₁ * exp(-cp.c₁ * t) + cp.b₂ * exp(-cp.c₂ * t) + cp.b₃ * exp(-cp.c₃ * t))
 end
-# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).
+FinanceCore.discount(cp::CairnsPritchardExtended, t) = _discount_from_zero(cp, t)

--- a/src/model/Yield/CairnsPritchard.jl
+++ b/src/model/Yield/CairnsPritchard.jl
@@ -22,7 +22,7 @@ See also [`CairnsPritchardExtended`](@ref) for a 3-component variant.
 # References
 - Cairns, A.J.G. (1998). "Descriptive Bond-Yield and Forward-Rate Models for the British Government Securities Market". British Actuarial Journal, 4(2), 265-321.
 """
-struct CairnsPritchard{T} <: AbstractYieldModel
+struct CairnsPritchard{T} <: AbstractZeroCurve
     c₁::T
     c₂::T
     b₀::T
@@ -49,8 +49,7 @@ function Base.zero(cp::CairnsPritchard, t)
     # At t=0 the formula is already well-defined: exp(0) = 1, so z(0) = b₀ + b₁ + b₂
     return Continuous(cp.b₀ + cp.b₁ * exp(-cp.c₁ * t) + cp.b₂ * exp(-cp.c₂ * t))
 end
-
-FinanceCore.discount(cp::CairnsPritchard, t) = discount.(zero.(cp, t), t)
+# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).
 
 """
     CairnsPritchardExtended(c₁, c₂, c₃, b₀, b₁, b₂, b₃)
@@ -77,7 +76,7 @@ See also [`CairnsPritchard`](@ref) for a 2-component variant.
 # References
 - Cairns, A.J.G. (1998). "Descriptive Bond-Yield and Forward-Rate Models for the British Government Securities Market". British Actuarial Journal, 4(2), 265-321.
 """
-struct CairnsPritchardExtended{T} <: AbstractYieldModel
+struct CairnsPritchardExtended{T} <: AbstractZeroCurve
     c₁::T
     c₂::T
     c₃::T
@@ -106,5 +105,4 @@ function Base.zero(cp::CairnsPritchardExtended, t)
     # At t=0 the formula is already well-defined: exp(0) = 1, so z(0) = b₀ + b₁ + b₂ + b₃
     return Continuous(cp.b₀ + cp.b₁ * exp(-cp.c₁ * t) + cp.b₂ * exp(-cp.c₂ * t) + cp.b₃ * exp(-cp.c₃ * t))
 end
-
-FinanceCore.discount(cp::CairnsPritchardExtended, t) = discount.(zero.(cp, t), t)
+# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).

--- a/src/model/Yield/MonotoneConvex.jl
+++ b/src/model/Yield/MonotoneConvex.jl
@@ -31,7 +31,7 @@ discount(c, 2.5)  # Get the discount factor at t=2.5
 - Hagan & West, "Interpolation Methods for Curve Construction", WILMOTT magazine
 - Dehlbom, "Interpolation of the yield curve" (http://uu.diva-portal.org/smash/get/diva2:1477828/FULLTEXT01.pdf)
 """
-struct MonotoneConvex{T, U} <: AbstractYieldModel
+struct MonotoneConvex{T, U} <: AbstractZeroCurve
     f::Vector{T}
     fᵈ::Vector{T}
     rates::Vector{T}
@@ -331,8 +331,4 @@ function Base.zero(mc::MonotoneConvex, t)
         return Continuous((t_prev * rates[i_time - 1] + (t - t_prev) * fᵈ[i_time] + (t_curr - t_prev) * G) / t)
     end
 end
-
-function FinanceCore.discount(mc::MonotoneConvex, t)
-    r = zero(mc, t)
-    return discount(r, t)
-end
+# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).

--- a/src/model/Yield/MonotoneConvex.jl
+++ b/src/model/Yield/MonotoneConvex.jl
@@ -31,7 +31,7 @@ discount(c, 2.5)  # Get the discount factor at t=2.5
 - Hagan & West, "Interpolation Methods for Curve Construction", WILMOTT magazine
 - Dehlbom, "Interpolation of the yield curve" (http://uu.diva-portal.org/smash/get/diva2:1477828/FULLTEXT01.pdf)
 """
-struct MonotoneConvex{T, U} <: AbstractZeroCurve
+struct MonotoneConvex{T, U} <: AbstractYieldModel
     f::Vector{T}
     fᵈ::Vector{T}
     rates::Vector{T}
@@ -331,4 +331,4 @@ function Base.zero(mc::MonotoneConvex, t)
         return Continuous((t_prev * rates[i_time - 1] + (t - t_prev) * fᵈ[i_time] + (t_curr - t_prev) * G) / t)
     end
 end
-# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).
+FinanceCore.discount(mc::MonotoneConvex, t) = _discount_from_zero(mc, t)

--- a/src/model/Yield/NelsonSiegelSvensson.jl
+++ b/src/model/Yield/NelsonSiegelSvensson.jl
@@ -65,6 +65,8 @@ function Base.zero(ns::NelsonSiegel, t)
     return Continuous(ns.β₀ + ns.β₁ * (1.0 - e) / q + ns.β₂ * ((1.0 - e) / q - e))
 end
 FinanceCore.discount(ns::NelsonSiegel, t) = _discount_from_zero(ns, t)
+Base.zero(ns::NelsonSiegel, ts::AbstractArray) = zero.(Ref(ns), ts)
+FinanceCore.discount(ns::NelsonSiegel, ts::AbstractArray) = discount.(Ref(ns), ts)
 
 """
     NelsonSiegelSvensson(τ₁, τ₂, β₀, β₁, β₂, β₃)
@@ -140,3 +142,5 @@ function Base.zero(nss::NelsonSiegelSvensson, t)
     return Continuous(nss.β₀ + nss.β₁ * (1.0 - e₁) / q₁ + nss.β₂ * ((1.0 - e₁) / q₁ - e₁) + nss.β₃ * ((1.0 - e₂) / q₂ - e₂))
 end
 FinanceCore.discount(nss::NelsonSiegelSvensson, t) = _discount_from_zero(nss, t)
+Base.zero(nss::NelsonSiegelSvensson, ts::AbstractArray) = zero.(Ref(nss), ts)
+FinanceCore.discount(nss::NelsonSiegelSvensson, ts::AbstractArray) = discount.(Ref(nss), ts)

--- a/src/model/Yield/NelsonSiegelSvensson.jl
+++ b/src/model/Yield/NelsonSiegelSvensson.jl
@@ -30,7 +30,7 @@ NelsonSiegel has generally been replaced by NelsonSiegelSvensson, which is a mor
 - https://onriskandreturn.com/2019/12/01/nelson-siegel-yield-curve-model/
 - https://www.bis.org/publ/bppdf/bispap25.pdf
 """
-struct NelsonSiegel{T} <: AbstractZeroCurve
+struct NelsonSiegel{T} <: AbstractYieldModel
     τ₁::T
     β₀::T
     β₁::T
@@ -57,13 +57,14 @@ end
 
 function Base.zero(ns::NelsonSiegel, t)
     iszero(t) && return Continuous(ns.β₀ + ns.β₁)  # lim_{t→0}: decay → 1, hump → 0
-    # Written inline (no factored `decay = (1-e)/x` intermediate) on purpose: the NSS
-    # fit is highly sensitive, and reassociating `(β·(1-e))/x` into `β·((1-e)/x)` shifts
-    # ForwardDiff gradients enough to tip the degenerate calibration into NaN. Keep this
-    # expression bit-for-bit as is.
-    return Continuous(ns.β₀ + ns.β₁ * (1.0 - exp(-t / ns.τ₁)) / (t / ns.τ₁) + ns.β₂ * ((1.0 - exp(-t / ns.τ₁)) / (t / ns.τ₁) - exp(-t / ns.τ₁)))
+    # Bind leaf subexpressions (q, e) only — do NOT combine into `decay = (1-e)/q` and
+    # write `β·decay`: that reassociates `(β·(1-e))/q → β·((1-e)/q)`, and the sub-ULP
+    # gradient shift tips the (documented, highly sensitive) NSS calibration into NaN.
+    q = t / ns.τ₁
+    e = exp(-q)
+    return Continuous(ns.β₀ + ns.β₁ * (1.0 - e) / q + ns.β₂ * ((1.0 - e) / q - e))
 end
-# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).
+FinanceCore.discount(ns::NelsonSiegel, t) = _discount_from_zero(ns, t)
 
 """
     NelsonSiegelSvensson(τ₁, τ₂, β₀, β₁, β₂, β₃)
@@ -105,7 +106,7 @@ Nelson-Siegel-Svensson Cons:
 - https://onriskandreturn.com/2019/12/01/nelson-siegel-yield-curve-model/
 - https://www.bis.org/publ/bppdf/bispap25.pdf
 """
-struct NelsonSiegelSvensson{T} <: AbstractZeroCurve
+struct NelsonSiegelSvensson{T} <: AbstractYieldModel
     τ₁::T
     τ₂::T
     β₀::T
@@ -129,9 +130,13 @@ NelsonSiegelSvensson(τ₁ = 1.0, τ₂ = 1.0) = NelsonSiegelSvensson(τ₁, τ�
 
 function Base.zero(nss::NelsonSiegelSvensson, t)
     iszero(t) && return Continuous(nss.β₀ + nss.β₁)  # lim_{t→0}: same as NelsonSiegel; β₂, β₃ vanish
-    # Inline (not factored) on purpose — see the NelsonSiegel `zero` above: reassociating
-    # into shared `decay` intermediates perturbs ForwardDiff gradients enough to tip the
-    # sensitive NSS calibration into NaN. Keep this expression bit-for-bit as is.
-    return Continuous(nss.β₀ + nss.β₁ * (1.0 - exp(-t / nss.τ₁)) / (t / nss.τ₁) + nss.β₂ * ((1.0 - exp(-t / nss.τ₁)) / (t / nss.τ₁) - exp(-t / nss.τ₁)) + nss.β₃ * ((1.0 - exp(-t / nss.τ₂)) / (t / nss.τ₂) - exp(-t / nss.τ₂)))
+    # Bind leaf subexpressions (q, e) only — see the NelsonSiegel `zero` above. Do NOT
+    # combine into shared `decay = (1-e)/q` intermediates: reassociating the `β·(1-e)/q`
+    # products shifts ForwardDiff gradients enough to tip the sensitive NSS fit into NaN.
+    q₁ = t / nss.τ₁
+    q₂ = t / nss.τ₂
+    e₁ = exp(-q₁)
+    e₂ = exp(-q₂)
+    return Continuous(nss.β₀ + nss.β₁ * (1.0 - e₁) / q₁ + nss.β₂ * ((1.0 - e₁) / q₁ - e₁) + nss.β₃ * ((1.0 - e₂) / q₂ - e₂))
 end
-# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).
+FinanceCore.discount(nss::NelsonSiegelSvensson, t) = _discount_from_zero(nss, t)

--- a/src/model/Yield/NelsonSiegelSvensson.jl
+++ b/src/model/Yield/NelsonSiegelSvensson.jl
@@ -30,7 +30,7 @@ NelsonSiegel has generally been replaced by NelsonSiegelSvensson, which is a mor
 - https://onriskandreturn.com/2019/12/01/nelson-siegel-yield-curve-model/
 - https://www.bis.org/publ/bppdf/bispap25.pdf
 """
-struct NelsonSiegel{T} <: AbstractYieldModel
+struct NelsonSiegel{T} <: AbstractZeroCurve
     τ₁::T
     β₀::T
     β₁::T
@@ -56,13 +56,14 @@ function NelsonSiegel(τ₁ = 1.0)
 end
 
 function Base.zero(ns::NelsonSiegel, t)
-    if iszero(t)
-        # lim_{t→0} z(t) = β₀ + β₁ (the (1-e^(-x))/x terms → 1, hump term vanishes)
-        return Continuous(ns.β₀ + ns.β₁)
-    end
-    return Continuous.(ns.β₀ .+ ns.β₁ .* (1.0 .- exp.(-t ./ ns.τ₁)) ./ (t ./ ns.τ₁) .+ ns.β₂ .* ((1.0 .- exp.(-t ./ ns.τ₁)) ./ (t ./ ns.τ₁) .- exp.(-t ./ ns.τ₁)))
+    iszero(t) && return Continuous(ns.β₀ + ns.β₁)  # lim_{t→0}: decay → 1, hump → 0
+    # Written inline (no factored `decay = (1-e)/x` intermediate) on purpose: the NSS
+    # fit is highly sensitive, and reassociating `(β·(1-e))/x` into `β·((1-e)/x)` shifts
+    # ForwardDiff gradients enough to tip the degenerate calibration into NaN. Keep this
+    # expression bit-for-bit as is.
+    return Continuous(ns.β₀ + ns.β₁ * (1.0 - exp(-t / ns.τ₁)) / (t / ns.τ₁) + ns.β₂ * ((1.0 - exp(-t / ns.τ₁)) / (t / ns.τ₁) - exp(-t / ns.τ₁)))
 end
-FinanceCore.discount(ns::NelsonSiegel, t) = discount.(zero.(ns, t), t)
+# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).
 
 """
     NelsonSiegelSvensson(τ₁, τ₂, β₀, β₁, β₂, β₃)
@@ -104,7 +105,7 @@ Nelson-Siegel-Svensson Cons:
 - https://onriskandreturn.com/2019/12/01/nelson-siegel-yield-curve-model/
 - https://www.bis.org/publ/bppdf/bispap25.pdf
 """
-struct NelsonSiegelSvensson{T} <: AbstractYieldModel
+struct NelsonSiegelSvensson{T} <: AbstractZeroCurve
     τ₁::T
     τ₂::T
     β₀::T
@@ -127,10 +128,10 @@ end
 NelsonSiegelSvensson(τ₁ = 1.0, τ₂ = 1.0) = NelsonSiegelSvensson(τ₁, τ₂, 0.0, 0.0, 0.0, 0.0)
 
 function Base.zero(nss::NelsonSiegelSvensson, t)
-    if iszero(t)
-        # lim_{t→0} z(t) = β₀ + β₁ (same limit as NelsonSiegel; β₂, β₃ hump terms vanish)
-        return Continuous(nss.β₀ + nss.β₁)
-    end
-    return Continuous.(nss.β₀ .+ nss.β₁ .* (1.0 .- exp.(-t ./ nss.τ₁)) ./ (t ./ nss.τ₁) .+ nss.β₂ .* ((1.0 .- exp.(-t ./ nss.τ₁)) ./ (t ./ nss.τ₁) .- exp.(-t ./ nss.τ₁)) .+ nss.β₃ .* ((1.0 .- exp.(-t ./ nss.τ₂)) ./ (t ./ nss.τ₂) .- exp.(-t ./ nss.τ₂)))
+    iszero(t) && return Continuous(nss.β₀ + nss.β₁)  # lim_{t→0}: same as NelsonSiegel; β₂, β₃ vanish
+    # Inline (not factored) on purpose — see the NelsonSiegel `zero` above: reassociating
+    # into shared `decay` intermediates perturbs ForwardDiff gradients enough to tip the
+    # sensitive NSS calibration into NaN. Keep this expression bit-for-bit as is.
+    return Continuous(nss.β₀ + nss.β₁ * (1.0 - exp(-t / nss.τ₁)) / (t / nss.τ₁) + nss.β₂ * ((1.0 - exp(-t / nss.τ₁)) / (t / nss.τ₁) - exp(-t / nss.τ₁)) + nss.β₃ * ((1.0 - exp(-t / nss.τ₂)) / (t / nss.τ₂) - exp(-t / nss.τ₂)))
 end
-FinanceCore.discount(nss::NelsonSiegelSvensson, t) = discount.(zero.(nss, t), t)
+# `discount` is inherited from `AbstractZeroCurve` (discount ∘ zero).

--- a/src/model/Yield/ZeroRateCurve.jl
+++ b/src/model/Yield/ZeroRateCurve.jl
@@ -92,8 +92,7 @@ function FinanceCore.discount(zrc::ZeroRateCurve, t)
     t < zero(t) && throw(DomainError(t, "ZeroRateCurve discount is only defined for t ≥ 0"))
     return discount(zrc._model, t)
 end
-
-(zrc::ZeroRateCurve)(t) = FinanceCore.discount(zrc, t)
+# The callable `zrc(t) ≡ discount(zrc, t)` comes from the generic `AbstractYieldModel` fallback.
 
 # Structural equality on the value-carrying fields. The `_model` field is a
 # deterministic function of (rates, tenors, spline) and may not implement `==`

--- a/test/ZeroRatePrimitive.jl
+++ b/test/ZeroRatePrimitive.jl
@@ -19,6 +19,15 @@
     comp_sub = spl - splc
     scaled = spl * 0.79
     shifted = spl + ((z, t) -> z + Continuous(0.01))
+    zrc = ZeroRateCurve(zrates, mats, Spline.Linear())
+    sw = Yield.SmithWilson([5.0, 7.0], [2.3, -1.2]; ufr = 0.03, α = 0.1)
+    spread = Yield.Constant(0.01)
+    wrapped_discount_native = [
+        ("ZeroRateCurve + spread", zrc + spread),
+        ("SmithWilson + spread", sw + spread),
+        ("Scaled SmithWilson", sw * 0.79),
+        ("Scaled ForwardStarting", Yield.ForwardStarting(sw, 1.0) * 2.0),
+    ]
 
     curves = [
         ("Spline(linear)", spl), ("Spline(cubic)", splc), ("MonotoneConvex", mc),
@@ -38,6 +47,16 @@
 
     @testset "discount(c, 0) == 1 exactly  ($name)" for (name, c) in curves
         @test discount(c, 0.0) == 1.0
+    end
+
+    @testset "discount(c, 0) == 1 over discount-native wrappers  ($name)" for (name, c) in wrapped_discount_native
+        @test discount(c, 0.0) == 1.0
+        @test isfinite(discount(c, 0.0, 5.0))
+    end
+
+    @testset "present_value through a discount-native wrapper is finite" begin
+        bond = Bond.Fixed(0.05, Periodic(1), 5)
+        @test isfinite(present_value(zrc + spread, bond))
     end
 
     @testset "zero(c, 0) is finite (regression: was 0/0 → NaN)" begin

--- a/test/ZeroRatePrimitive.jl
+++ b/test/ZeroRatePrimitive.jl
@@ -42,7 +42,8 @@
 
     @testset "zero(c, 0) is finite (regression: was 0/0 → NaN)" begin
         for (name, c) in (("Spline", spl), ("Constant(cont)", cc),
-            ("Constant(per)", cper), ("Composite(+)", comp_add), ("Scaled", scaled))
+            ("Constant(per)", cper), ("Composite(+)", comp_add), ("Scaled", scaled),
+            ("MonotoneConvex", mc), ("NelsonSiegel", ns), ("NSS", nss), ("CairnsPritchard", cpr))
             @test !isnan(FinanceCore.rate(zero(c, 0.0)))
         end
         # flat curve: zero(·, 0) is its own continuous rate

--- a/test/ZeroRatePrimitive.jl
+++ b/test/ZeroRatePrimitive.jl
@@ -53,6 +53,21 @@
         @test FinanceCore.rate(zero(comp_add, 1e-9)) ≈ FinanceCore.rate(zero(comp_add, 0.0)) atol = 1e-6
     end
 
+    @testset "NS/NSS array tenors preserve scalar semantics" begin
+        ts = [0.0, 0.5, 2.0, 10.0]
+        for c in (ns, nss)
+            @test zero(c, ts) == zero.(Ref(c), ts)
+            @test discount(c, ts) == discount.(Ref(c), ts)
+        end
+    end
+
+    @testset "discount(c, 0) preserves curve numeric type" begin
+        ns_big = Yield.NelsonSiegel(big"2.0", big"0.03", big"-0.01", big"0.01")
+        scaled_big = Yield.Constant(big"0.03") * big"0.79"
+        @test discount(ns_big, 0.0) isa BigFloat
+        @test discount(scaled_big, 0.0) isa BigFloat
+    end
+
     @testset "composition is additive in zero-rate space" begin
         for t in (0.5, 1.0, 5.0, 20.0)
             z1 = FinanceCore.rate(zero(spl, t))


### PR DESCRIPTION
## Summary

An audit-driven consolidation of the yield-curve module that finishes the direction of #264 (continuous zero rate as the curve primitive). No behavior change — the full suite (incl. Aqua and the audit regressions) passes, and NS/NSS fits reproduce identical parameters to master.

> **Updated after review:** the first iteration introduced an `AbstractZeroCurve` supertype to host the shared `discount`. Per review, that's a high bar for a one-method category (and "zero-native" is an implementation detail — even `ZeroRateCurve` isn't zero-native), so it was replaced with an internal helper. See commit history.

### A. Consolidate discount-from-zero via an internal helper
Adds one internal helper:

```julia
function _discount_from_zero(c, t)\n    df = discount(Base.zero(c, t), t)\n    return iszero(t) ? one(df) : df\nend
```

Eight previously-duplicated `discount` definitions become a one-line stub each. The helper preserves `DF(0) = 1` for wrappers over discount-native curves while deriving the result type from the rate-level discount (`discount(c::T, t) = _discount_from_zero(c, t)`): `CompositeYield`, `ScaledYield`, `AbstractYieldShift` (covers Tenor/Projected), `NelsonSiegel`, `NelsonSiegelSvensson`, `CairnsPritchard`, `CairnsPritchardExtended`, `MonotoneConvex`. `Constant` and `Spline` keep their own cheaper `discount`. No new public type; a curve defining neither `zero` nor `discount` now gets a clean `MethodError` rather than mutual recursion.

### B. De-duplicate `present_value`
`present_value(model, ::AbstractContract)` delegates to the single discounting fold defined for `Projection` instead of carrying a verbatim copy.

### C. Remove redundant callables
The generic `(::AbstractYieldModel)(t)` fallback (added in #262) already covers every subtype, so the bespoke `Spline` / `MonotoneConvex` / `ZeroRateCurve` callables are removed.

### D. NelsonSiegel/NSS `zero` readability
Removed the vestigial broadcasting and factored **leaf** subexpressions only (`q = t/τ`, `e = exp(-q)`) — bit-for-bit identical under primal and ForwardDiff, computes `exp` once.

## ⚠️ One subtlety worth a careful look

The NS/NSS `zero` factorization binds **leaves only** and never reassociates the `β·(1-e)/q` products. Combining into a `decay = (1-e)/q` intermediate reassociates `(β·(1-e))/q → β·((1-e)/q)`, and since `a*(b/c) ≠ (a*b)/c` in IEEE arithmetic, that sub-ULP shift tips the (documented, pathologically sensitive) NSS calibration into `NaN` on the EURAAA test. The committed form reproduces master's fit exactly (`β₂ = -9.999999962766292`); code comments warn against re-factoring. Test tolerances are untouched.

## Follow-up (separate issue, to be filed)

The NSS EURAAA fit is **boundary-pinned** (`τ₁=100`, `β₂=−10` — both on their box constraints), a degenerate calibration that currently passes only on loose tolerances. Per project philosophy it should **error loudly** when a parametric fit converges on its bounds, rather than warn or silently return a degenerate curve. Tracked separately; out of scope here.

## Verification
- `Pkg.test()` clean on master (baseline) and this branch (incl. Aqua, regressions, ZeroRatePrimitive, NelsonSiegelSvensson).
- Smoke-checked `discount(c,0)==1`, `c(t) ≡ discount(c,t)`, `discount ≈ exp(-z·t)` for every curve type.
- NSS fit reproduces master's parameters to all digits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)