### PR TITLE
Fix CIR Monte Carlo bias (true full truncation); exact Gaussian transitions for Vasicek/Hull-White

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceModels"
 uuid = "77f2ae65-bdde-421f-ae9d-22f1af19dd76"
-version = "6.2.0"
+version = "6.2.1"
 authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
 
 [deps]

--- a/docs/src/stochastic.md
+++ b/docs/src/stochastic.md
@@ -159,7 +159,7 @@ Custom bounds can be passed via the `variables` keyword argument to `fit`.
 
 ### Generating Scenarios with `simulate`
 
-`simulate` uses Euler-Maruyama discretisation to generate interest-rate paths. Each path is returned as a [`RatePath`](@ref FinanceModels.RatePath), which is itself an `AbstractYieldModel` -- so `discount`, `zero`, `forward`, `par`, and `present_value` all work on individual scenarios.
+`simulate` generates interest-rate paths using the exact Gaussian transition density for Vasicek and Hull-White (no discretisation bias in the short rate at any timestep) and the full truncation scheme (Lord, Koekkoek & Van Dijk, 2010) for Cox-Ingersoll-Ross. Each path is returned as a [`RatePath`](@ref FinanceModels.RatePath), which is itself an `AbstractYieldModel` -- so `discount`, `zero`, `forward`, `par`, and `present_value` all work on individual scenarios.
 
 ```julia
 using Random
@@ -365,7 +365,7 @@ hw_fit = fit(hw0, quotes)
 
 ### Model Behaviour
 
-- **CIR Feller condition:** The CIR model requires `2ab > σ²` for the short rate to stay strictly positive. When this condition is violated, the rate can reach zero. The simulation uses the full truncation scheme (absorption at zero) in that case.
+- **CIR Feller condition:** The CIR model requires `2ab > σ²` for the short rate to stay strictly positive. When this condition is violated, the rate can reach zero. The simulation uses the full truncation scheme: an auxiliary process may go negative while the observed rate is floored at zero. Discretisation bias grows with `σ²/(2ab)`, so use a finer `timestep` (e.g. weekly instead of monthly) when the Feller condition is strongly violated.
 - **Vasicek negative rates:** The Vasicek model allows negative rates by design. For very negative rates or long horizons, discount factors may exceed 1 (equivalently, zero rates are negative). This is consistent with observed negative-rate environments.
 
 ### Performance Guidance

--- a/src/model/Stochastic.jl
+++ b/src/model/Stochastic.jl
@@ -65,8 +65,11 @@ Cox-Ingersoll-Ross (1985) mean-reverting short-rate model:
 
 !!! note "Feller condition"
     The condition `2ab > σ²` is required for the variance process to stay strictly
-    positive. When violated, the short rate can reach zero; simulation uses absorption
-    at zero (full truncation scheme) in that case.
+    positive. When violated, the short rate can reach zero; simulation uses the
+    full truncation scheme (Lord, Koekkoek & Van Dijk, 2010), which lets an
+    auxiliary process go negative while the observed rate is floored at zero.
+    Discretisation bias grows with `σ²/(2ab)` — use a finer `timestep` when the
+    Feller condition is strongly violated.
 """
 struct CoxIngersollRoss{A,B,S,T} <: AbstractStochasticModel
     a::A
@@ -237,16 +240,27 @@ function FinanceCore.discount(p::RatePath, t)
     return exp(-p.interp(t))
 end
 
-# ─── simulate: Euler-Maruyama path generation ────────────────────────────────
+# ─── simulate: path generation ───────────────────────────────────────────────
 
 """
     simulate(model::AbstractStochasticModel;
              n_scenarios=1000, timestep=1/12, horizon=30.0,
              rng=Random.default_rng())
 
-Generate `n_scenarios` interest-rate paths via Euler-Maruyama discretisation.
+Generate `n_scenarios` interest-rate paths.
 Each path is returned as a `RatePath` (an `AbstractYieldModel`) so it plugs
 directly into `present_value`, `discount`, etc.
+
+Discretisation schemes:
+- **Vasicek / Hull-White**: the exact Gaussian transition density, so the
+  simulated short rate has no discretisation bias at any `timestep`.
+- **Cox-Ingersoll-Ross**: full truncation (Lord, Koekkoek & Van Dijk, 2010) —
+  an auxiliary process may go negative while the observed rate is `max(x, 0)`.
+  Weak bias vanishes as `timestep → 0`, but is material for coarse steps when
+  the Feller condition is strongly violated.
+
+In all cases the cumulative discount integral ``∫₀ᵗ r(s)\\,ds`` is accumulated
+with the trapezoidal rule between grid points.
 """
 function simulate(model::AbstractStochasticModel;
                   n_scenarios::Int = 1000,
@@ -258,7 +272,7 @@ function simulate(model::AbstractStochasticModel;
     n_steps = ceil(Int, horizon / dt)
     sqrt_dt = sqrt(dt)
 
-    drift_cache = _precompute_drift(model, dt, n_steps)
+    cache = _sim_cache(model, dt, n_steps)
 
     # Determine element type from initial rate (may be a ForwardDiff.Dual)
     r0 = _sim_initial_rate(model)
@@ -280,8 +294,9 @@ function simulate(model::AbstractStochasticModel;
         for j in 1:n_steps
             Z = randn(rng)
             t = (j - 1) * dt
-            r_new = _step(model, r, dt, sqrt_dt, Z, t, drift_cache, j)
-            cumulative[j + 1] = cumulative[j] + 0.5 * (r + r_new) * dt
+            r_new = _step(model, r, dt, sqrt_dt, Z, t, cache, j)
+            cumulative[j + 1] = cumulative[j] +
+                0.5 * (_observed_rate(model, r) + _observed_rate(model, r_new)) * dt
             r = r_new
         end
         interp = DataInterpolations.LinearInterpolation(
@@ -299,41 +314,62 @@ function _sim_initial_rate(m::ShortRate.HullWhite)
     return _hw_forward_rate(m.curve, 0.0)
 end
 
-# Euler-Maruyama step for each model
-function _step(m::ShortRate.Vasicek, r, dt, sqrt_dt, Z, t, ::Nothing, j)
-    return r + m.a * (m.b - r) * dt + m.σ * sqrt_dt * Z
+# Exact Ornstein-Uhlenbeck transition parameters over one step of length dt:
+#   x_{t+dt} | x_t ~ Normal(x_t·ϕ, sd²),  ϕ = exp(-a·dt),  sd² = σ²(1-ϕ²)/(2a)
+function _ou_step_params(a, σ, dt)
+    ϕ = exp(-a * dt)
+    var = abs(a) < 1e-12 ? σ^2 * dt : σ^2 * (-expm1(-2a * dt)) / (2a)
+    return (ϕ = ϕ, sd = sqrt(var))
 end
 
-function _step(m::ShortRate.CoxIngersollRoss, r, dt, sqrt_dt, Z, t, ::Nothing, j)
-    # Full truncation scheme (Lord, Koekkoek & Van Dijk, 2010)
-    r_pos = max(r, 0.0)
-    return max(r_pos + m.a * (m.b - r_pos) * dt + m.σ * sqrt(r_pos) * sqrt_dt * Z, 0.0)
+# The rate that enters the discount integral: identity except for CIR, where
+# the state is the full-truncation auxiliary process and the rate is its
+# positive part.
+_observed_rate(::AbstractStochasticModel, r) = r
+_observed_rate(::ShortRate.CoxIngersollRoss, x) = max(x, zero(x))
+
+# Vasicek: exact transition r' = b + (r-b)ϕ + sd·Z (no discretisation bias)
+function _step(m::ShortRate.Vasicek, r, dt, sqrt_dt, Z, t, ou, j)
+    return m.b + (r - m.b) * ou.ϕ + ou.sd * Z
 end
 
-function _step(m::ShortRate.HullWhite, r, dt, sqrt_dt, Z, t, θ_cache, j)
-    return r + (θ_cache[j] - m.a * r) * dt + m.σ * sqrt_dt * Z
+# CIR: full truncation scheme (Lord, Koekkoek & Van Dijk, 2010).
+# The state is an auxiliary process x that may go negative; drift and
+# diffusion use x⁺ and the observed rate is x⁺ (see `_observed_rate`).
+# Flooring x itself at zero (absorption) would bias E[exp(-∫r)] down
+# materially when the Feller condition is violated.
+function _step(m::ShortRate.CoxIngersollRoss, x, dt, sqrt_dt, Z, t, ::Nothing, j)
+    xp = max(x, zero(x))
+    return x + m.a * (m.b - xp) * dt + m.σ * sqrt(xp) * sqrt_dt * Z
 end
 
-# Compute θ(t) = f_t(0,t) + a·f(0,t) + (σ²/2a)·(1 - exp(-2at))
-# where f(0,t) is the instantaneous forward rate from the initial curve
-function _hw_theta(m::ShortRate.HullWhite, t)
+# Hull-White: exact transition via the decomposition r(t) = x(t) + α(t)
+# where dx = -a·x dt + σ dW (OU with zero mean, simulated exactly) and
+# α(t) = f(0,t) + σ²/(2a²)(1 - exp(-at))² (Brigo & Mercurio 2006, Eq. 3.36).
+# This avoids differentiating the forward curve (θ(t) needs f_t(0,t)) and has
+# no discretisation bias in r.
+function _step(m::ShortRate.HullWhite, r, dt, sqrt_dt, Z, t, cache, j)
+    x = r - cache.α[j]  # cache.α[j] = α(t_{j-1})
+    return x * cache.ou.ϕ + cache.ou.sd * Z + cache.α[j + 1]
+end
+
+function _hw_alpha(m::ShortRate.HullWhite, t)
     a, σ = m.a, m.σ
     f0t = _hw_forward_rate(m.curve, t)
-    df_dt = DifferentiationInterface.derivative(
-        s -> _hw_forward_rate(m.curve, s),
-        AutoForwardDiff(), max(t, 1e-10)
-    )
     if abs(a) < 1e-12
-        return df_dt + σ^2 * t
+        return f0t + σ^2 * t^2 / 2
     else
-        return df_dt + a * f0t + σ^2 / (2a) * (1 - exp(-2a * t))
+        return f0t + σ^2 / (2a^2) * (1 - exp(-a * t))^2
     end
 end
 
-# Pre-compute drift values: nothing for Vasicek/CIR, Vector{Float64} for HW
-_precompute_drift(::AbstractStochasticModel, dt, n_steps) = nothing
-function _precompute_drift(m::ShortRate.HullWhite, dt, n_steps)
-    return [_hw_theta(m, (j - 1) * dt) for j in 1:n_steps]
+# Per-simulation cache: OU transition parameters for the Gaussian models
+# (plus the α(t) grid for Hull-White); nothing for CIR.
+_sim_cache(::AbstractStochasticModel, dt, n_steps) = nothing
+_sim_cache(m::ShortRate.Vasicek, dt, n_steps) = _ou_step_params(m.a, m.σ, dt)
+function _sim_cache(m::ShortRate.HullWhite, dt, n_steps)
+    return (ou = _ou_step_params(m.a, m.σ, dt),
+            α = [_hw_alpha(m, j * dt) for j in 0:n_steps])
 end
 
 # ─── pv_mc: Monte Carlo expected present value ───────────────────────────────
@@ -617,7 +653,7 @@ The instantaneous short rate `r(t)` for a simulated scenario.
 `RatePath` stores the cumulative integral `∫₀ᵗ r(s) ds` as a `LinearInterpolation`.
 The short rate is the derivative of this cumulative integral.
 
-Because the cumulative integral is built from Euler-Maruyama trapezoidal steps, the
+Because the cumulative integral is built from trapezoidal steps, the
 returned rate is piecewise-constant within each timestep — an approximation to the
 continuous short-rate process, not the exact value.
 """

--- a/src/model/Stochastic.jl
+++ b/src/model/Stochastic.jl
@@ -326,10 +326,9 @@ end
 
 # The rate that enters the discount integral: identity except for CIR, where
 # the state is the full-truncation auxiliary process and the rate is its
-# positive part. Defined per concrete model (no abstract fallback) so that a
-# new model type fails loudly instead of silently integrating its raw state.
-_observed_rate(::ShortRate.Vasicek, r) = r
-_observed_rate(::ShortRate.HullWhite, r) = r
+# positive part. The abstract fallback preserves the extension contract for
+# custom stochastic models whose simulated state is their observed rate.
+_observed_rate(::AbstractStochasticModel, r) = r
 _observed_rate(::ShortRate.CoxIngersollRoss, x) = max(x, zero(x))
 
 # Vasicek: exact transition r' = b + (r-b)ϕ + sd·Z (no discretisation bias)
@@ -368,9 +367,9 @@ function _hw_alpha(m::ShortRate.HullWhite, t)
 end
 
 # Per-simulation cache: OU transition parameters for the Gaussian models
-# (plus the α(t) grid for Hull-White); nothing for CIR. Defined per concrete
-# model (no abstract fallback) so that a new model type fails loudly.
-_sim_cache(::ShortRate.CoxIngersollRoss, dt, n_steps) = nothing
+# (plus the α(t) grid for Hull-White). Models that do not need a cache,
+# including CIR and custom AbstractStochasticModel subtypes, receive `nothing`.
+_sim_cache(::AbstractStochasticModel, dt, n_steps) = nothing
 _sim_cache(m::ShortRate.Vasicek, dt, n_steps) = _ou_step_params(m.a, m.σ, dt)
 function _sim_cache(m::ShortRate.HullWhite, dt, n_steps)
     return (ou = _ou_step_params(m.a, m.σ, dt),

--- a/src/model/Stochastic.jl
+++ b/src/model/Stochastic.jl
@@ -82,7 +82,7 @@ function CoxIngersollRoss(a::Real, b::Real, σ::Real, initial::Real)
     σ >= 0 || throw(ArgumentError("volatility σ must be non-negative, got $σ"))
     initial >= 0 || throw(ArgumentError("initial rate must be non-negative for CIR, got $initial"))
     if 2 * a * b <= σ^2
-        @warn "Feller condition 2ab > σ² violated (2·$(a)·$(b) = $(2*a*b) ≤ σ² = $(σ^2)). Short rate may reach zero."
+        @warn "Feller condition 2ab > σ² violated (2·$(a)·$(b) = $(2*a*b) ≤ σ² = $(σ^2)). Short rate may reach zero, and `simulate`'s discretisation bias grows with σ²/(2ab) — prefer a finer `timestep`."
     end
     return CoxIngersollRoss(Float64(a), Float64(b), Float64(σ), Continuous(initial))
 end
@@ -260,7 +260,9 @@ Discretisation schemes:
   the Feller condition is strongly violated.
 
 In all cases the cumulative discount integral ``∫₀ᵗ r(s)\\,ds`` is accumulated
-with the trapezoidal rule between grid points.
+with the trapezoidal rule between grid points, so pathwise discount factors
+(and hence `pv_mc`) retain an integration error that grows with `timestep`
+even when the short-rate transition itself is exact.
 """
 function simulate(model::AbstractStochasticModel;
                   n_scenarios::Int = 1000,
@@ -324,13 +326,15 @@ end
 
 # The rate that enters the discount integral: identity except for CIR, where
 # the state is the full-truncation auxiliary process and the rate is its
-# positive part.
-_observed_rate(::AbstractStochasticModel, r) = r
+# positive part. Defined per concrete model (no abstract fallback) so that a
+# new model type fails loudly instead of silently integrating its raw state.
+_observed_rate(::ShortRate.Vasicek, r) = r
+_observed_rate(::ShortRate.HullWhite, r) = r
 _observed_rate(::ShortRate.CoxIngersollRoss, x) = max(x, zero(x))
 
 # Vasicek: exact transition r' = b + (r-b)ϕ + sd·Z (no discretisation bias)
-function _step(m::ShortRate.Vasicek, r, dt, sqrt_dt, Z, t, ou, j)
-    return m.b + (r - m.b) * ou.ϕ + ou.sd * Z
+function _step(m::ShortRate.Vasicek, r, dt, sqrt_dt, Z, t, cache, j)
+    return m.b + (r - m.b) * cache.ϕ + cache.sd * Z
 end
 
 # CIR: full truncation scheme (Lord, Koekkoek & Van Dijk, 2010).
@@ -364,8 +368,9 @@ function _hw_alpha(m::ShortRate.HullWhite, t)
 end
 
 # Per-simulation cache: OU transition parameters for the Gaussian models
-# (plus the α(t) grid for Hull-White); nothing for CIR.
-_sim_cache(::AbstractStochasticModel, dt, n_steps) = nothing
+# (plus the α(t) grid for Hull-White); nothing for CIR. Defined per concrete
+# model (no abstract fallback) so that a new model type fails loudly.
+_sim_cache(::ShortRate.CoxIngersollRoss, dt, n_steps) = nothing
 _sim_cache(m::ShortRate.Vasicek, dt, n_steps) = _ou_step_params(m.a, m.σ, dt)
 function _sim_cache(m::ShortRate.HullWhite, dt, n_steps)
     return (ou = _ou_step_params(m.a, m.σ, dt),

--- a/test/Stochastic.jl
+++ b/test/Stochastic.jl
@@ -520,12 +520,17 @@ using Random
     end
 
     @testset "CIR ZCB analytical regression" begin
-        # These values are computed from the CIR closed-form ZCB formula
-        # (Cox, Ingersoll & Ross, 1985, Econometrica, Eq. 23). They serve
-        # as regression tests across Feller-condition regimes.
+        # Closed-form CIR ZCB prices (Cox, Ingersoll & Ross, 1985, Econometrica,
+        # Eq. 23), verified against two independent implementations:
+        # - Feller-satisfied sets: QuantLib 1.42.1 `CoxIngersollRoss::discountBond`
+        #   reproduces every value below to all 12 printed decimals.
+        # - Feller-boundary/violated sets (QuantLib rejects such parameters at
+        #   construction): numerical integration of the affine Riccati ODEs
+        #   B' = 1 - aB - σ²B²/2, (ln A)' = -abB with scipy solve_ivp at
+        #   rtol=1e-12 matches to ~1e-13.
 
         @testset "Feller satisfied: a=0.3, b=0.08, σ=0.15, r₀=0.05" begin
-            # 2ab = 0.048 > σ² = 0.0225
+            # 2ab = 0.048 > σ² = 0.0225. Independent source: QuantLib 1.42.1
             cir = ShortRate.CoxIngersollRoss(0.3, 0.08, 0.15, Continuous(0.05))
             @test discount(cir, 1.0) ≈ 0.947503053857 atol = 1e-8
             @test discount(cir, 5.0) ≈ 0.731755780942 atol = 1e-8
@@ -534,7 +539,7 @@ using Random
         end
 
         @testset "Higher vol: a=0.5, b=0.10, σ=0.20, r₀=0.05" begin
-            # 2ab = 0.10 > σ² = 0.04
+            # 2ab = 0.10 > σ² = 0.04. Independent source: QuantLib 1.42.1
             cir = ShortRate.CoxIngersollRoss(0.5, 0.10, 0.20, Continuous(0.05))
             @test discount(cir, 1.0) ≈ 0.941394105702 atol = 1e-8
             @test discount(cir, 5.0) ≈ 0.673617793268 atol = 1e-8
@@ -543,7 +548,8 @@ using Random
         end
 
         @testset "Feller boundary: σ = √(2ab)" begin
-            # At the exact Feller boundary: 2ab = σ², process can touch zero
+            # At the exact Feller boundary: 2ab = σ², process can touch zero.
+            # Independent source: Riccati ODE integration (see testset header)
             a, b = 0.5, 0.10
             σ_bdy = sqrt(2 * a * b)  # ≈ 0.3162
             cir = ShortRate.CoxIngersollRoss(a, b, σ_bdy, Continuous(0.05))
@@ -553,7 +559,8 @@ using Random
         end
 
         @testset "Feller violated: σ=0.50 > √(2ab)=0.316" begin
-            # 2ab = 0.10 < σ² = 0.25 — formula still valid, higher convexity
+            # 2ab = 0.10 < σ² = 0.25 — formula still valid, higher convexity.
+            # Independent source: Riccati ODE integration (see testset header)
             cir = ShortRate.CoxIngersollRoss(0.5, 0.10, 0.50, Continuous(0.05))
             @test discount(cir, 1.0) ≈ 0.942631527602 atol = 1e-8
             @test discount(cir, 5.0) ≈ 0.708602161384 atol = 1e-8
@@ -562,6 +569,16 @@ using Random
             # Higher vol → more convexity → higher bond prices
             cir_lo = ShortRate.CoxIngersollRoss(0.5, 0.10, 0.10, Continuous(0.05))
             @test discount(cir, 5.0) > discount(cir_lo, 5.0)
+        end
+
+        @testset "Feller strongly violated: a=0.1, b=0.10, σ=0.50, r₀=0.05" begin
+            # 2ab = 0.02 ≪ σ² = 0.25 — the truth standard for the Feller-violated
+            # martingale test below. Independent source: Riccati ODE integration
+            # (see testset header); matches to ~1e-13.
+            cir = ShortRate.CoxIngersollRoss(0.1, 0.10, 0.50, Continuous(0.05))
+            @test discount(cir, 1.0) ≈ 0.950729464416 atol = 1e-9
+            @test discount(cir, 5.0) ≈ 0.821656416270 atol = 1e-9
+            @test discount(cir, 10.0) ≈ 0.723687625316 atol = 1e-9
         end
 
         @testset "QuantLib near-deterministic: a=1.0, b=0.1, σ≈0, r₀=0.1" begin
@@ -661,6 +678,7 @@ using Random
             # Vasicek r(T)|r(0) ~ Normal(E[r(T)], Var[r(T)])
             # E[r(T)] = b + (r₀−b)exp(−aT)
             # Var[r(T)] = σ²(1−exp(−2aT))/(2a)
+            # Source: Vasicek (1977); Brigo & Mercurio (2006) §3.2.1
             a, b, σ, r0 = 0.3, 0.10, 0.03, 0.03
             v = ShortRate.Vasicek(a, b, σ, Continuous(r0))
             T = 5.0
@@ -668,10 +686,15 @@ using Random
             V_rT = σ^2 * (1 - exp(-2a * T)) / (2a)
 
             N = 10_000
-            # Quarter-year steps: the transition is sampled from the exact
-            # Gaussian density, so coarse steps introduce NO bias — only
-            # sampling error remains.
-            dt = 0.25
+            # ONE-YEAR steps: the transition is sampled from the exact Gaussian
+            # density, so even absurdly coarse steps introduce no bias — only
+            # sampling error remains. This step size is chosen to discriminate:
+            # an Euler-Maruyama scheme at dt=1 has deterministic moment errors
+            # of 2.6× the mean tolerance and +20% on the variance (vs 5% rtol),
+            # so a regression to Euler fails this test decisively. (At dt=0.25
+            # Euler's errors sit just inside both tolerances — too fine a step
+            # proves nothing.)
+            dt = 1.0
             n_steps = round(Int, T / dt)
             sqrt_dt = sqrt(dt)
             cache = FinanceModels._sim_cache(v, dt, n_steps)
@@ -697,6 +720,7 @@ using Random
             # CIR r(T)|r(0) has known moments:
             # E[r(T)] = b + (r₀−b)exp(−aT)
             # Var[r(T)] = r₀σ²exp(−aT)(1−exp(−aT))/a + bσ²(1−exp(−aT))²/(2a)
+            # Source: Cox, Ingersoll & Ross (1985); Brigo & Mercurio (2006) §3.2.3
             a, b, σ, r0 = 0.3, 0.08, 0.15, 0.05
             cir = ShortRate.CoxIngersollRoss(a, b, σ, Continuous(r0))
             T = 5.0
@@ -762,7 +786,9 @@ using Random
             # (flooring the state at zero each step) was biased by −6% to
             # −17% here and would fail this tolerance by an order of
             # magnitude; full truncation keeps the bias within tens of bp
-            # at weekly steps.
+            # at weekly steps. The closed-form truth standard is itself
+            # independently verified (Riccati ODE) in the "Feller strongly
+            # violated" regression testset above.
             cir_fv = ShortRate.CoxIngersollRoss(0.1, 0.10, 0.50, Continuous(0.05))
             rng = Random.MersenneTwister(42)
             scenarios = simulate(cir_fv; n_scenarios = 20_000, timestep = 1 / 52, horizon = 11.0, rng)

--- a/test/Stochastic.jl
+++ b/test/Stochastic.jl
@@ -1,5 +1,12 @@
 using Random
 
+struct TestStochasticModel <: AbstractStochasticModel
+    initial::Float64
+end
+
+FinanceModels._sim_initial_rate(m::TestStochasticModel) = m.initial
+FinanceModels._step(::TestStochasticModel, r, dt, sqrt_dt, Z, t, ::Nothing, j) = r
+
 @testset "Stochastic Models" begin
 
     @testset "Vasicek" begin
@@ -716,6 +723,38 @@ using Random
             @test sample_var ≈ V_rT rtol = 0.05
         end
 
+        @testset "Hull-White r(T) moments (exact transition, coarse steps)" begin
+            # Under r(t) = x(t) + α(t), x is a zero-mean OU process, hence
+            # E[r(T)] = α(T) and Var[r(T)] = σ²(1−exp(−2aT))/(2a).
+            # One-year steps make this test reject the former Euler transition
+            # while leaving the exact transition unaffected by the step size.
+            a, σ = 0.1, 0.02
+            hw = ShortRate.HullWhite(a, σ, Yield.Constant(Continuous(0.03)))
+            T = 5.0
+            E_rT = FinanceModels._hw_alpha(hw, T)
+            V_rT = σ^2 * (1 - exp(-2a * T)) / (2a)
+
+            N = 10_000
+            dt = 1.0
+            n_steps = round(Int, T / dt)
+            sqrt_dt = sqrt(dt)
+            cache = FinanceModels._sim_cache(hw, dt, n_steps)
+            rng = Random.MersenneTwister(42)
+            rates = Vector{Float64}(undef, N)
+            for i in 1:N
+                r = FinanceModels._sim_initial_rate(hw)
+                for j in 1:n_steps
+                    r = FinanceModels._step(hw, r, dt, sqrt_dt, randn(rng), (j - 1) * dt, cache, j)
+                end
+                rates[i] = r
+            end
+            sample_mean = sum(rates) / N
+            sample_var = sum((r - sample_mean)^2 for r in rates) / (N - 1)
+
+            @test sample_mean ≈ E_rT atol = 4 * sqrt(V_rT) / sqrt(N)
+            @test sample_var ≈ V_rT rtol = 0.05
+        end
+
         @testset "CIR r(T) moments" begin
             # CIR r(T)|r(0) has known moments:
             # E[r(T)] = b + (r₀−b)exp(−aT)
@@ -866,6 +905,16 @@ using Random
     end
 
     # ──────────────────────────────────────────────────────────────────────────
+    @testset "Custom stochastic model simulation hooks" begin
+        # External AbstractStochasticModel subtypes historically needed only an
+        # initial-state extractor and a step method when no cache was required.
+        model = TestStochasticModel(0.03)
+        scenarios = simulate(model; n_scenarios = 2, timestep = 0.5,
+                             horizon = 1.0, rng = Random.MersenneTwister(42))
+        @test length(scenarios) == 2
+        @test all(discount(path, 1.0) ≈ exp(-0.03) for path in scenarios)
+    end
+
     # AD forward rate correctness
     # ──────────────────────────────────────────────────────────────────────────
 

--- a/test/Stochastic.jl
+++ b/test/Stochastic.jl
@@ -448,7 +448,7 @@ using Random
         for T in [1.0, 5.0, 10.0]
             expected_disc = sum(discount(sc, T) for sc in scenarios) / 5000
             curve_disc = discount(curve, T)
-            @test expected_disc ≈ curve_disc rtol = 0.02
+            @test expected_disc ≈ curve_disc rtol = 0.01
         end
     end
 
@@ -657,25 +657,30 @@ using Random
     # ──────────────────────────────────────────────────────────────────────────
 
     @testset "Analytical moment matching" begin
-        @testset "Vasicek r(T) moments" begin
+        @testset "Vasicek r(T) moments (exact transition, coarse steps)" begin
             # Vasicek r(T)|r(0) ~ Normal(E[r(T)], Var[r(T)])
             # E[r(T)] = b + (r₀−b)exp(−aT)
             # Var[r(T)] = σ²(1−exp(−2aT))/(2a)
             a, b, σ, r0 = 0.3, 0.10, 0.03, 0.03
+            v = ShortRate.Vasicek(a, b, σ, Continuous(r0))
             T = 5.0
             E_rT = b + (r0 - b) * exp(-a * T)
             V_rT = σ^2 * (1 - exp(-2a * T)) / (2a)
 
             N = 10_000
-            dt = 1 / 52  # weekly steps to reduce EM bias
-            n_steps = ceil(Int, T / dt)
+            # Quarter-year steps: the transition is sampled from the exact
+            # Gaussian density, so coarse steps introduce NO bias — only
+            # sampling error remains.
+            dt = 0.25
+            n_steps = round(Int, T / dt)
             sqrt_dt = sqrt(dt)
+            cache = FinanceModels._sim_cache(v, dt, n_steps)
             rng = Random.MersenneTwister(42)
             rates = Vector{Float64}(undef, N)
             for i in 1:N
                 r = Float64(r0)
-                for _ in 1:n_steps
-                    r = r + a * (b - r) * dt + σ * sqrt_dt * randn(rng)
+                for j in 1:n_steps
+                    r = FinanceModels._step(v, r, dt, sqrt_dt, randn(rng), (j - 1) * dt, cache, j)
                 end
                 rates[i] = r
             end
@@ -693,6 +698,7 @@ using Random
             # E[r(T)] = b + (r₀−b)exp(−aT)
             # Var[r(T)] = r₀σ²exp(−aT)(1−exp(−aT))/a + bσ²(1−exp(−aT))²/(2a)
             a, b, σ, r0 = 0.3, 0.08, 0.15, 0.05
+            cir = ShortRate.CoxIngersollRoss(a, b, σ, Continuous(r0))
             T = 5.0
             E_rT = b + (r0 - b) * exp(-a * T)
             V_rT = r0 * σ^2 * exp(-a * T) * (1 - exp(-a * T)) / a +
@@ -705,12 +711,13 @@ using Random
             rng = Random.MersenneTwister(42)
             rates = Vector{Float64}(undef, N)
             for i in 1:N
-                r = Float64(r0)
-                for _ in 1:n_steps
-                    r_pos = max(r, 0.0)
-                    r = max(r_pos + a * (b - r_pos) * dt + σ * sqrt(r_pos) * sqrt_dt * randn(rng), 0.0)
+                # x is the full-truncation auxiliary state (may go negative);
+                # the observed short rate is x⁺
+                x = Float64(r0)
+                for j in 1:n_steps
+                    x = FinanceModels._step(cir, x, dt, sqrt_dt, randn(rng), (j - 1) * dt, nothing, j)
                 end
-                rates[i] = r
+                rates[i] = FinanceModels._observed_rate(cir, x)
             end
             sample_mean = sum(rates) / N
             sample_var = sum((r - sample_mean)^2 for r in rates) / (N - 1)
@@ -728,13 +735,15 @@ using Random
     @testset "Martingale test E[D(T)] = P(0,T)" begin
         @testset "Vasicek" begin
             # Under risk-neutral measure, mean simulated discount factor
-            # must equal the analytical ZCB price
+            # must equal the analytical ZCB price. The exact Gaussian
+            # transition leaves only trapezoidal-integration and sampling
+            # error, so the tolerance can be tight.
             v = ShortRate.Vasicek(0.3, 0.10, 0.03, Continuous(0.03))
             rng = Random.MersenneTwister(42)
             scenarios = simulate(v; n_scenarios = 10_000, timestep = 1 / 12, horizon = 11.0, rng)
             for T in [1.0, 5.0, 10.0]
                 mc_disc = sum(discount(sc, T) for sc in scenarios) / 10_000
-                @test mc_disc ≈ discount(v, T) rtol = 0.015
+                @test mc_disc ≈ discount(v, T) rtol = 0.01
             end
         end
 
@@ -744,7 +753,22 @@ using Random
             scenarios = simulate(cir; n_scenarios = 10_000, timestep = 1 / 12, horizon = 11.0, rng)
             for T in [1.0, 5.0, 10.0]
                 mc_disc = sum(discount(sc, T) for sc in scenarios) / 10_000
-                @test mc_disc ≈ discount(cir, T) rtol = 0.02
+                @test mc_disc ≈ discount(cir, T) rtol = 0.01
+            end
+        end
+
+        @testset "CIR with Feller violation" begin
+            # 2ab = 0.02 < σ² = 0.25. The absorption scheme this replaced
+            # (flooring the state at zero each step) was biased by −6% to
+            # −17% here and would fail this tolerance by an order of
+            # magnitude; full truncation keeps the bias within tens of bp
+            # at weekly steps.
+            cir_fv = ShortRate.CoxIngersollRoss(0.1, 0.10, 0.50, Continuous(0.05))
+            rng = Random.MersenneTwister(42)
+            scenarios = simulate(cir_fv; n_scenarios = 20_000, timestep = 1 / 52, horizon = 11.0, rng)
+            for T in [5.0, 10.0]
+                mc_disc = sum(discount(sc, T) for sc in scenarios) / 20_000
+                @test mc_disc ≈ discount(cir_fv, T) rtol = 0.02
             end
         end
     end
@@ -925,7 +949,7 @@ using Random
             scenarios = simulate(hw; n_scenarios = 5000, timestep = 1 / 12, horizon = 11.0, rng)
             for T in [1.0, 5.0, 10.0]
                 mc_disc = sum(discount(sc, T) for sc in scenarios) / 5000
-                @test mc_disc ≈ discount(curve, T) rtol = 0.02
+                @test mc_disc ≈ discount(curve, T) rtol = 0.01
             end
         end
     end
@@ -979,6 +1003,12 @@ using Random
         for sc in scenarios
             @test discount(sc, 3.0) > 0
             @test isfinite(discount(sc, 3.0))
+            # Only the truncated (non-negative) rate may enter the discount
+            # integral, so pathwise discounts are non-increasing in T even
+            # when the auxiliary state goes negative
+            @test discount(sc, 4.0) <= discount(sc, 3.0)
+            # short_rate reports the observed (truncated) rate
+            @test short_rate(sc, 2.5) >= 0
         end
     end
 


### PR DESCRIPTION
## Problem

An accuracy assessment of the Monte Carlo functionality (`simulate` / `pv_mc`) found two issues, measured by comparing `mean(discount(path, T))` against the closed-form ZCB prices at 50k–100k paths:

**1. CIR simulation was severely biased under Feller violation.** `_step` floored the state at zero every step (absorption) while the docstring and comment claimed the Lord–Koekkoek–van Dijk (2010) full truncation scheme. Genuine full truncation keeps the negative "shadow" value and truncates only inside the drift/diffusion and the observed rate. With `a=0.1, b=0.10, σ=0.50` (2ab = 0.02 < σ² = 0.25):

| scheme | dt | T=5 | T=10 |
|---|---|---|---|
| absorption (before) | 1/12 | **−855 bp** | **−2063 bp** |
| absorption (before) | 1/52 | −638 bp | −1652 bp |
| full truncation (after) | 1/12 | −84 bp | −66 bp |
| full truncation (after) | 1/52 | −24 bp | −20 bp |

Note the absorption bias barely improved with timestep refinement; the fixed scheme converges in dt. This matters in practice because the code steers CIR swaption pricing to `pv_mc` (Jamshidian needs Gaussian models), and calibrated CIR parameters routinely violate Feller. Feller-satisfied CIR was unbiased before and after (<7 bp, within noise).

**2. Vasicek/Hull-White carried an avoidable O(dt) Euler–Maruyama bias** (−13 to −17 bp at T=5–10 with monthly steps, σ=3%, 2–3σ significant at 100k paths). Both models are Gaussian, so the exact OU transition density costs nothing extra:

- Vasicek: `r' = b + (r−b)e^{−a·dt} + σ√((1−e^{−2a·dt})/2a)·Z`
- Hull-White: `r(t) = x(t) + α(t)` with `x` an exact zero-mean OU and `α(t) = f(0,t) + σ²/(2a²)(1−e^{−at})²` (Brigo & Mercurio Eq. 3.36)

After the change, martingale bias is within sampling noise (≤1σ at 100k–200k paths) at any timestep; only trapezoidal integration of ∫r ds remains. The HW decomposition also eliminates θ(t), which needed a second derivative of the forward curve through AD — one less thing to go wrong on bootstrapped/spline curves.

## Changes

- `_step(CIR)`: evolve the shadow state; `x⁺` in drift/diffusion; new `_observed_rate` hook so only `max(x,0)` enters the trapezoidal discount integral (and hence `short_rate`)
- `_step(Vasicek/HullWhite)`: exact Gaussian transitions via a precomputed `_ou_step_params` cache (`_precompute_drift` renamed `_sim_cache`); `_hw_theta` removed
- Docstrings and `docs/src/stochastic.md` now describe the actual schemes, including the CIR guidance to use finer timesteps under strong Feller violation
- Version 6.2.0 → 6.2.1

## Tests

- New Feller-violated CIR martingale test (rtol 2% at weekly steps) — the absorption scheme fails it by an order of magnitude
- Martingale tolerances tightened from rtol 1.5–2% to 1% (the old tolerances could not detect either bug)
- Moment-matching tests now exercise the package `_step` instead of re-implementing the old Euler scheme inline; the Vasicek test runs at coarse quarter-year steps to prove the transition is exact
- Pathwise `discount` monotonicity + `short_rate ≥ 0` assertions guard against the shadow state leaking into the integral
- Full suite passes locally (3,197 tests incl. Aqua)

🤖 Generated with [Claude Code](https://claude.com/claude-code)