### PR TITLE
Generalize instantaneous_forward beyond MonotoneConvex (v6.3.0)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceModels"
 uuid = "77f2ae65-bdde-421f-ae9d-22f1af19dd76"
-version = "6.2.0"
+version = "6.3.0"
 authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
 
 [deps]

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -1,5 +1,9 @@
 # Migration Guide
 
+## v6.2 to v6.3
+
+- **`Yield.instantaneous_forward` now returns a `Continuous` `Rate` instead of a bare `Real`**, consistent with `zero`, `forward`, and `par`. Use `rate(instantaneous_forward(m, t))` where you consumed the scalar. (The `Real`-returning `MonotoneConvex` method existed only in v6.1–v6.2; this release also adds analytic methods for `Constant`, `Spline`, `NelsonSiegel(-Svensson)`, `ZeroRateCurve`, and the `+`/`-`/scaling/`ForwardStarting` wrappers.)
+
 ## v6.0 to v6.1
 
 !!! warning "Changed numbers and new errors"

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -632,5 +632,58 @@ function Base.:/(a::AbstractYieldModel, b::Real)
     return ScaledYield(a, inv(b))
 end
 
+## Instantaneous forward rates
+
+"""
+    instantaneous_forward(model, t)
+
+The instantaneous (continuously compounded) forward rate of the curve at time `t`,
+
+    f(t) = ∂/∂t (−log P(t)) = z(t) + t·z′(t),
+
+returned as a `Real` (matching the convention of the `MonotoneConvex` method that
+predates the generic definitions).
+
+This is distinct from [`forward`](@ref)`(curve, from, to)`, which is the *discrete*
+forward `Rate` between two times and is defined for every yield model.
+
+Methods are defined where the instantaneous forward has an analytic form:
+
+- `Constant` — the (continuous) rate itself
+- `Spline` — via the interpolant's derivative
+- `MonotoneConvex` — the Hagan–West forward directly
+- `NelsonSiegel` / `NelsonSiegelSvensson` — closed form
+- `ZeroRateCurve` — delegates to its interpolation model
+- the wrappers `CompositeYield` (for `+`/`-`), `ScaledYield`, and `ForwardStarting`
+
+Models without a defined method (e.g. discount-native models such as `SmithWilson`
+or the short-rate models) throw a `MethodError` rather than silently approximating;
+use finite differences of `-log(discount(m, t))` or AD explicitly if needed.
+"""
+function instantaneous_forward end
+
+# A flat curve's instantaneous forward is its continuous rate at every tenor.
+instantaneous_forward(c::Constant, t) = FinanceCore.rate(convert(Continuous(), c.rate))
+
+# `c.fn` maps time to the continuous zero rate, so f(t) = z(t) + t·z′(t) with the
+# interpolant's analytic derivative.
+function instantaneous_forward(c::Spline, t)
+    z = c.fn(t)
+    z′ = DataInterpolations.derivative(c.fn, t)
+    return z + t * z′
+end
+
+# CompositeYield composes zero rates with `op`; for the linear ops (+/−, the only ones
+# the public `+`/`-` constructors create) the forward composes the same way:
+# f = d/dt[t·op(z₁, z₂)] = op(f₁, f₂). Nonlinear ops have no such identity, so no
+# generic CompositeYield method is defined.
+instantaneous_forward(rc::CompositeYield{T, U, typeof(+)}, t) where {T, U} = instantaneous_forward(rc.r1, t) + instantaneous_forward(rc.r2, t)
+instantaneous_forward(rc::CompositeYield{T, U, typeof(-)}, t) where {T, U} = instantaneous_forward(rc.r1, t) - instantaneous_forward(rc.r2, t)
+
+# Scaling z(t) by a constant scales t·z(t), and hence its derivative, by the same factor.
+instantaneous_forward(sy::ScaledYield, t) = sy.factor * instantaneous_forward(sy.curve, t)
+
+# −log P_fwd(t) = −log P(t + s) + log P(s); differentiating in t rebases the forward.
+instantaneous_forward(c::ForwardStarting, t) = instantaneous_forward(c.curve, t + c.forwardstart)
 
 end

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -637,12 +637,17 @@ end
 """
     instantaneous_forward(model, t)
 
-The instantaneous (continuously compounded) forward rate of the curve at time `t`,
+The instantaneous forward rate of the curve at time `t`,
 
     f(t) = ∂/∂t (−log P(t)) = z(t) + t·z′(t),
 
-returned as a `Real` (matching the convention of the `MonotoneConvex` method that
-predates the generic definitions).
+returned as a `Continuous` `Rate` — the instantaneous forward is by definition
+continuously compounded, and returning a `Rate` keeps it consistent with `zero`,
+`forward`, and `par`, and composable with `discount`/`accumulation`. Use
+`rate(instantaneous_forward(m, t))` for the scalar value.
+
+(In v6.1–v6.2, the only method — `MonotoneConvex` — returned a bare `Real`; that
+inconsistency with the rest of the API is treated as a fix here.)
 
 This is distinct from [`forward`](@ref)`(curve, from, to)`, which is the *discrete*
 forward `Rate` between two times and is defined for every yield model.
@@ -660,14 +665,19 @@ Models without a defined method (e.g. discount-native models such as `SmithWilso
 or the short-rate models) throw a `MethodError` rather than silently approximating;
 use finite differences of `-log(discount(m, t))` or AD explicitly if needed.
 """
-function instantaneous_forward end
+instantaneous_forward(m, t) = Continuous(_instantaneous_forward(m, t))
+
+# Per-model raw-scalar kernels; the single public method above wraps the result in
+# `Continuous`. Keeping the kernels in plain floats lets the wrapper methods below
+# compose forwards with ordinary arithmetic.
+function _instantaneous_forward end
 
 # A flat curve's instantaneous forward is its continuous rate at every tenor.
-instantaneous_forward(c::Constant, t) = FinanceCore.rate(convert(Continuous(), c.rate))
+_instantaneous_forward(c::Constant, t) = FinanceCore.rate(convert(Continuous(), c.rate))
 
 # `c.fn` maps time to the continuous zero rate, so f(t) = z(t) + t·z′(t) with the
 # interpolant's analytic derivative.
-function instantaneous_forward(c::Spline, t)
+function _instantaneous_forward(c::Spline, t)
     z = c.fn(t)
     z′ = DataInterpolations.derivative(c.fn, t)
     return z + t * z′
@@ -677,13 +687,13 @@ end
 # the public `+`/`-` constructors create) the forward composes the same way:
 # f = d/dt[t·op(z₁, z₂)] = op(f₁, f₂). Nonlinear ops have no such identity, so no
 # generic CompositeYield method is defined.
-instantaneous_forward(rc::CompositeYield{T, U, typeof(+)}, t) where {T, U} = instantaneous_forward(rc.r1, t) + instantaneous_forward(rc.r2, t)
-instantaneous_forward(rc::CompositeYield{T, U, typeof(-)}, t) where {T, U} = instantaneous_forward(rc.r1, t) - instantaneous_forward(rc.r2, t)
+_instantaneous_forward(rc::CompositeYield{T, U, typeof(+)}, t) where {T, U} = _instantaneous_forward(rc.r1, t) + _instantaneous_forward(rc.r2, t)
+_instantaneous_forward(rc::CompositeYield{T, U, typeof(-)}, t) where {T, U} = _instantaneous_forward(rc.r1, t) - _instantaneous_forward(rc.r2, t)
 
 # Scaling z(t) by a constant scales t·z(t), and hence its derivative, by the same factor.
-instantaneous_forward(sy::ScaledYield, t) = sy.factor * instantaneous_forward(sy.curve, t)
+_instantaneous_forward(sy::ScaledYield, t) = sy.factor * _instantaneous_forward(sy.curve, t)
 
 # −log P_fwd(t) = −log P(t + s) + log P(s); differentiating in t rebases the forward.
-instantaneous_forward(c::ForwardStarting, t) = instantaneous_forward(c.curve, t + c.forwardstart)
+_instantaneous_forward(c::ForwardStarting, t) = _instantaneous_forward(c.curve, t + c.forwardstart)
 
 end

--- a/src/model/Yield/MonotoneConvex.jl
+++ b/src/model/Yield/MonotoneConvex.jl
@@ -194,18 +194,12 @@ function g_rate(x, f⁻, f, fᵈ)
     end
 end
 
-"""
-    instantaneous_forward(mc::MonotoneConvex, t)
-
-The instantaneous (continuously-compounded) forward rate of the Hagan-West
-interpolant at time `t`. Beyond the last knot the forward is extrapolated flat
-at the boundary instantaneous forward `f(t_n)`, so the forward curve is
-continuous everywhere, including at the last knot.
-
-Note this is distinct from `forward(curve, from, to)`, which is the *discrete*
-forward `Rate` between two times and is defined for every yield model.
-"""
-function instantaneous_forward(mc::MonotoneConvex, t)
+# Raw-scalar kernel for the Hagan-West instantaneous forward; the public
+# `instantaneous_forward` (see Yield.jl) wraps the result in `Continuous`.
+# Beyond the last knot the forward is extrapolated flat at the boundary
+# instantaneous forward `f(t_n)`, so the forward curve is continuous everywhere,
+# including at the last knot.
+function _instantaneous_forward(mc::MonotoneConvex, t)
     f, fᵈ, times = mc.f, mc.fᵈ, mc.times
     lt = last(times)
 

--- a/src/model/Yield/NelsonSiegelSvensson.jl
+++ b/src/model/Yield/NelsonSiegelSvensson.jl
@@ -64,6 +64,15 @@ function Base.zero(ns::NelsonSiegel, t)
 end
 FinanceCore.discount(ns::NelsonSiegel, t) = discount.(zero.(ns, t), t)
 
+# The NS zero rate is the running average of the closed-form instantaneous forward
+# f(t) = β₀ + β₁·e^(−t/τ₁) + β₂·(t/τ₁)·e^(−t/τ₁); z(t) = (1/t)∫₀ᵗ f(s)ds recovers
+# the `zero` expression above. f(0) = β₀ + β₁, matching `zero`'s t=0 limit.
+function instantaneous_forward(ns::NelsonSiegel, t)
+    x = t / ns.τ₁
+    e = exp(-x)
+    return ns.β₀ + ns.β₁ * e + ns.β₂ * x * e
+end
+
 """
     NelsonSiegelSvensson(τ₁, τ₂, β₀, β₁, β₂, β₃)
     NelsonSiegelSvensson(τ₁=1.0, τ₂=1.0)
@@ -134,3 +143,13 @@ function Base.zero(nss::NelsonSiegelSvensson, t)
     return Continuous.(nss.β₀ .+ nss.β₁ .* (1.0 .- exp.(-t ./ nss.τ₁)) ./ (t ./ nss.τ₁) .+ nss.β₂ .* ((1.0 .- exp.(-t ./ nss.τ₁)) ./ (t ./ nss.τ₁) .- exp.(-t ./ nss.τ₁)) .+ nss.β₃ .* ((1.0 .- exp.(-t ./ nss.τ₂)) ./ (t ./ nss.τ₂) .- exp.(-t ./ nss.τ₂)))
 end
 FinanceCore.discount(nss::NelsonSiegelSvensson, t) = discount.(zero.(nss, t), t)
+
+# Svensson adds a second hump term to the NS closed-form forward:
+# f(t) = β₀ + β₁·e^(−t/τ₁) + β₂·(t/τ₁)·e^(−t/τ₁) + β₃·(t/τ₂)·e^(−t/τ₂)
+function instantaneous_forward(nss::NelsonSiegelSvensson, t)
+    x₁ = t / nss.τ₁
+    x₂ = t / nss.τ₂
+    e₁ = exp(-x₁)
+    e₂ = exp(-x₂)
+    return nss.β₀ + nss.β₁ * e₁ + nss.β₂ * x₁ * e₁ + nss.β₃ * x₂ * e₂
+end

--- a/src/model/Yield/NelsonSiegelSvensson.jl
+++ b/src/model/Yield/NelsonSiegelSvensson.jl
@@ -67,7 +67,7 @@ FinanceCore.discount(ns::NelsonSiegel, t) = discount.(zero.(ns, t), t)
 # The NS zero rate is the running average of the closed-form instantaneous forward
 # f(t) = β₀ + β₁·e^(−t/τ₁) + β₂·(t/τ₁)·e^(−t/τ₁); z(t) = (1/t)∫₀ᵗ f(s)ds recovers
 # the `zero` expression above. f(0) = β₀ + β₁, matching `zero`'s t=0 limit.
-function instantaneous_forward(ns::NelsonSiegel, t)
+function _instantaneous_forward(ns::NelsonSiegel, t)
     x = t / ns.τ₁
     e = exp(-x)
     return ns.β₀ + ns.β₁ * e + ns.β₂ * x * e
@@ -146,7 +146,7 @@ FinanceCore.discount(nss::NelsonSiegelSvensson, t) = discount.(zero.(nss, t), t)
 
 # Svensson adds a second hump term to the NS closed-form forward:
 # f(t) = β₀ + β₁·e^(−t/τ₁) + β₂·(t/τ₁)·e^(−t/τ₁) + β₃·(t/τ₂)·e^(−t/τ₂)
-function instantaneous_forward(nss::NelsonSiegelSvensson, t)
+function _instantaneous_forward(nss::NelsonSiegelSvensson, t)
     x₁ = t / nss.τ₁
     x₂ = t / nss.τ₂
     e₁ = exp(-x₁)

--- a/src/model/Yield/ZeroRateCurve.jl
+++ b/src/model/Yield/ZeroRateCurve.jl
@@ -95,6 +95,13 @@ end
 
 (zrc::ZeroRateCurve)(t) = FinanceCore.discount(zrc, t)
 
+# The prebuilt interpolation model (Spline or MonotoneConvex) carries the analytic
+# instantaneous forward; the curve just delegates. Same t ≥ 0 domain as `discount`.
+function instantaneous_forward(zrc::ZeroRateCurve, t)
+    t < zero(t) && throw(DomainError(t, "ZeroRateCurve instantaneous_forward is only defined for t ≥ 0"))
+    return instantaneous_forward(zrc._model, t)
+end
+
 # Structural equality on the value-carrying fields. The `_model` field is a
 # deterministic function of (rates, tenors, spline) and may not implement `==`
 # on its underlying interpolation; ignoring it here keeps `a == b` meaningful

--- a/src/model/Yield/ZeroRateCurve.jl
+++ b/src/model/Yield/ZeroRateCurve.jl
@@ -97,9 +97,9 @@ end
 
 # The prebuilt interpolation model (Spline or MonotoneConvex) carries the analytic
 # instantaneous forward; the curve just delegates. Same t ≥ 0 domain as `discount`.
-function instantaneous_forward(zrc::ZeroRateCurve, t)
+function _instantaneous_forward(zrc::ZeroRateCurve, t)
     t < zero(t) && throw(DomainError(t, "ZeroRateCurve instantaneous_forward is only defined for t ≥ 0"))
-    return instantaneous_forward(zrc._model, t)
+    return _instantaneous_forward(zrc._model, t)
 end
 
 # Structural equality on the value-carrying fields. The `_model` field is a

--- a/test/MonotoneConvex.jl
+++ b/test/MonotoneConvex.jl
@@ -1,5 +1,8 @@
 @testset "Monotone Convex" begin
 
+    # scalar value of the Continuous Rate returned by instantaneous_forward
+    ifwd(m, t) = rate(Yield.instantaneous_forward(m, t))
+
     # Interpolation of the yield curve, Gustaf Dehlbom
     # http://uu.diva-portal.org/smash/get/diva2:1477828/FULLTEXT01.pdf
 
@@ -152,22 +155,22 @@
 
         @testset "$name" for (name, c) in curves
             # Forward at t=0 should equal instantaneous forward f[1]
-            @test Yield.instantaneous_forward(c, 0.0) ≈ c.f[1] atol = 1.0e-10
+            @test ifwd(c, 0.0) ≈ c.f[1] atol = 1.0e-10
 
             # Forward at internal knot points equals the instantaneous forward f[i+1]
             # (at x=1 of the interval ending at that knot)
             @testset "forward at knot t=$t" for (i, t) in enumerate(times[1:(end - 1)])
-                @test Yield.instantaneous_forward(c, t) ≈ c.f[i + 1] atol = 1.0e-10
+                @test ifwd(c, t) ≈ c.f[i + 1] atol = 1.0e-10
             end
 
             # Forward at/beyond the last knot equals the boundary instantaneous
             # forward f[end], keeping the forward curve continuous at t_n
-            @test Yield.instantaneous_forward(c, times[end]) ≈ c.f[end] atol = 1.0e-10
+            @test ifwd(c, times[end]) ≈ c.f[end] atol = 1.0e-10
 
             # Forward should be continuous and positive everywhere, including across the last knot
             @testset "forward positive and continuous" begin
                 ts = range(0.01, 6.0, 120)
-                fwds = [Yield.instantaneous_forward(c, t) for t in ts]
+                fwds = [ifwd(c, t) for t in ts]
                 @test all(fwds .> 0)
 
                 # Check continuity: adjacent forward values shouldn't jump excessively
@@ -177,26 +180,26 @@
             end
 
             # Extrapolation: flat at the boundary instantaneous forward
-            @test Yield.instantaneous_forward(c, 6.0) ≈ c.f[end] atol = 1.0e-10
-            @test Yield.instantaneous_forward(c, 10.0) ≈ c.f[end] atol = 1.0e-10
+            @test ifwd(c, 6.0) ≈ c.f[end] atol = 1.0e-10
+            @test ifwd(c, 10.0) ≈ c.f[end] atol = 1.0e-10
 
             # Continuity exactly at the last knot (this used to jump from f[end] to fᵈ[end])
             @testset "continuity at the last knot" begin
                 ε = 1.0e-9
-                @test Yield.instantaneous_forward(c, times[end] - ε) ≈
-                    Yield.instantaneous_forward(c, times[end] + ε) atol = 1.0e-6
+                @test ifwd(c, times[end] - ε) ≈
+                    ifwd(c, times[end] + ε) atol = 1.0e-6
                 @test rate(zero(c, times[end] + 1.0e-6)) ≈ rate(zero(c, times[end])) atol = 1.0e-6
             end
 
             # Mid-interval forwards should be bounded by fᵈ ± max deviation
             @testset "mid-interval forward bounds" begin
                 # First interval: t ∈ (0, 1)
-                f_mid = Yield.instantaneous_forward(c, 0.5)
+                f_mid = ifwd(c, 0.5)
                 @test f_mid > 0  # Must be positive
                 @test abs(f_mid - c.fᵈ[1]) < max(abs(c.f[1] - c.fᵈ[1]), abs(c.f[2] - c.fᵈ[1])) + 0.001
 
                 # Second interval: t ∈ (1, 2)
-                f_mid = Yield.instantaneous_forward(c, 1.5)
+                f_mid = ifwd(c, 1.5)
                 @test f_mid > 0  # Must be positive
                 @test abs(f_mid - c.fᵈ[2]) < max(abs(c.f[2] - c.fᵈ[2]), abs(c.f[3] - c.fᵈ[2])) + 0.001
             end
@@ -228,7 +231,7 @@
 
             c = Yield.MonotoneConvex(rates, times)
             # the collared interpolant keeps instantaneous forwards nonnegative...
-            @test minimum(Yield.instantaneous_forward(c, t) for t in range(1.0e-6, 4.0, 1001)) >= -1.0e-12
+            @test minimum(ifwd(c, t) for t in range(1.0e-6, 4.0, 1001)) >= -1.0e-12
             # ...without giving up exact knot repricing (the g construction always
             # integrates to the discrete forwards regardless of node values)
             for (i, t) in enumerate(times)
@@ -246,14 +249,14 @@
         end
         # negative rates imply discount factors above 1 and finite forwards everywhere
         @test discount(c, 1.0) > 1.0
-        @test all(isfinite(Yield.instantaneous_forward(c, t)) for t in range(0.01, 6.0, 200))
+        @test all(isfinite(ifwd(c, t)) for t in range(0.01, 6.0, 200))
     end
 
     @testset "single knot" begin
         c = Yield.MonotoneConvex([0.03], [2.0])
         @test rate(zero(c, 2.0)) ≈ 0.03
         @test rate(zero(c, 1.0)) ≈ 0.03  # flat forward within the single interval
-        @test Yield.instantaneous_forward(c, 0.5) ≈ 0.03
+        @test ifwd(c, 0.5) ≈ 0.03
         @test rate(zero(c, 4.0)) ≈ 0.03  # constant-forward extrapolation
     end
 

--- a/test/instantaneous_forward.jl
+++ b/test/instantaneous_forward.jl
@@ -1,0 +1,73 @@
+@testset "instantaneous_forward" begin
+    # central finite difference of −log P(t), the definition of the instantaneous forward
+    fd(m, t; h = 1.0e-6) = (log(discount(m, t - h)) - log(discount(m, t + h))) / (2h)
+
+    @testset "Constant" begin
+        c = Yield.Constant(Periodic(0.04, 2))
+        f = Yield.instantaneous_forward(c, 5.0)
+        @test f ≈ rate(convert(Continuous(), Periodic(0.04, 2)))
+        @test f ≈ fd(c, 5.0) atol = 1.0e-8
+        # flat curve: same forward at every tenor
+        @test Yield.instantaneous_forward(c, 0.0) == Yield.instantaneous_forward(c, 30.0)
+    end
+
+    @testset "NelsonSiegel and NelsonSiegelSvensson" begin
+        ns = Yield.NelsonSiegel(3.0, 0.04, -0.02, 0.03)
+        for t in (0.5, 2.0, 7.3, 25.0)
+            @test Yield.instantaneous_forward(ns, t) ≈ fd(ns, t) atol = 1.0e-6
+        end
+        # f(0) = β₀ + β₁, matching zero's t=0 limit
+        @test Yield.instantaneous_forward(ns, 0.0) ≈ 0.04 - 0.02
+        @test Yield.instantaneous_forward(ns, 0.0) ≈ FinanceCore.rate(zero(ns, 0.0))
+
+        nss = Yield.NelsonSiegelSvensson(1.5, 3.0, 0.04, -0.02, 0.03, 0.015)
+        for t in (0.5, 2.0, 7.3, 25.0)
+            @test Yield.instantaneous_forward(nss, t) ≈ fd(nss, t) atol = 1.0e-6
+        end
+        @test Yield.instantaneous_forward(nss, 0.0) ≈ 0.04 - 0.02
+    end
+
+    @testset "Spline-backed ZeroRateCurve" begin
+        zs = [0.02, 0.025, 0.03, 0.035]
+        tenors = [1.0, 2.0, 5.0, 10.0]
+        for sp in (Spline.PCHIP(), Spline.Cubic(), Spline.Linear())
+            zrc = ZeroRateCurve(zs, tenors, sp)
+            # off-knot points (Linear has kinks at knots where f is undefined)
+            for t in (1.5, 3.7, 8.0)
+                @test Yield.instantaneous_forward(zrc, t) ≈ fd(zrc, t) atol = 1.0e-5
+            end
+        end
+
+        # MonotoneConvex-backed (default) delegates to the Hagan–West forward
+        zrc_mc = ZeroRateCurve(zs, tenors)
+        @test Yield.instantaneous_forward(zrc_mc, 3.0) ≈ fd(zrc_mc, 3.0) atol = 1.0e-5
+
+        @test_throws DomainError Yield.instantaneous_forward(zrc_mc, -1.0)
+    end
+
+    @testset "wrapper models" begin
+        a = Yield.Constant(0.03)
+        b = Yield.Constant(0.01)
+        ns = Yield.NelsonSiegel(3.0, 0.04, -0.02, 0.03)
+
+        # CompositeYield: forwards add/subtract for the +/− compositions
+        @test Yield.instantaneous_forward(a + b, 2.0) ≈
+            Yield.instantaneous_forward(a, 2.0) + Yield.instantaneous_forward(b, 2.0)
+        @test Yield.instantaneous_forward(ns - b, 2.0) ≈ fd(ns - b, 2.0) atol = 1.0e-6
+
+        # ScaledYield: forward scales with the curve
+        m = Yield.Constant(Continuous(0.05)) * 0.79
+        @test Yield.instantaneous_forward(m, 2.0) ≈ 0.05 * 0.79
+        @test Yield.instantaneous_forward(ns * 2.0, 4.0) ≈ fd(ns * 2.0, 4.0) atol = 1.0e-6
+
+        # ForwardStarting: forward is the base curve's forward shifted by the start
+        fs = Yield.ForwardStarting(ns, 1.0)
+        @test Yield.instantaneous_forward(fs, 2.0) ≈ Yield.instantaneous_forward(ns, 3.0)
+        @test Yield.instantaneous_forward(fs, 2.0) ≈ fd(fs, 2.0) atol = 1.0e-6
+    end
+
+    @testset "discount-native models error rather than approximate" begin
+        sw = Yield.SmithWilson([1.0, 2.0], [0.1, 0.2]; ufr = 0.03, α = 0.1)
+        @test_throws MethodError Yield.instantaneous_forward(sw, 1.0)
+    end
+end

--- a/test/instantaneous_forward.jl
+++ b/test/instantaneous_forward.jl
@@ -1,30 +1,40 @@
 @testset "instantaneous_forward" begin
     # central finite difference of −log P(t), the definition of the instantaneous forward
     fd(m, t; h = 1.0e-6) = (log(discount(m, t - h)) - log(discount(m, t + h))) / (2h)
+    # scalar value of the returned Continuous Rate, for comparison against fd
+    ifwd(m, t) = rate(Yield.instantaneous_forward(m, t))
+
+    @testset "returns a Continuous Rate" begin
+        c = Yield.Constant(Periodic(0.04, 2))
+        f = Yield.instantaneous_forward(c, 5.0)
+        @test f isa Rate
+        @test f == convert(Continuous(), Periodic(0.04, 2))
+        # composes with the rest of the Rate API
+        @test discount(f, 1.0) ≈ discount(c, 5.0, 6.0)
+    end
 
     @testset "Constant" begin
         c = Yield.Constant(Periodic(0.04, 2))
-        f = Yield.instantaneous_forward(c, 5.0)
-        @test f ≈ rate(convert(Continuous(), Periodic(0.04, 2)))
-        @test f ≈ fd(c, 5.0) atol = 1.0e-8
+        @test ifwd(c, 5.0) ≈ rate(convert(Continuous(), Periodic(0.04, 2)))
+        @test ifwd(c, 5.0) ≈ fd(c, 5.0) atol = 1.0e-8
         # flat curve: same forward at every tenor
-        @test Yield.instantaneous_forward(c, 0.0) == Yield.instantaneous_forward(c, 30.0)
+        @test ifwd(c, 0.0) == ifwd(c, 30.0)
     end
 
     @testset "NelsonSiegel and NelsonSiegelSvensson" begin
         ns = Yield.NelsonSiegel(3.0, 0.04, -0.02, 0.03)
         for t in (0.5, 2.0, 7.3, 25.0)
-            @test Yield.instantaneous_forward(ns, t) ≈ fd(ns, t) atol = 1.0e-6
+            @test ifwd(ns, t) ≈ fd(ns, t) atol = 1.0e-6
         end
         # f(0) = β₀ + β₁, matching zero's t=0 limit
-        @test Yield.instantaneous_forward(ns, 0.0) ≈ 0.04 - 0.02
-        @test Yield.instantaneous_forward(ns, 0.0) ≈ FinanceCore.rate(zero(ns, 0.0))
+        @test ifwd(ns, 0.0) ≈ 0.04 - 0.02
+        @test ifwd(ns, 0.0) ≈ FinanceCore.rate(zero(ns, 0.0))
 
         nss = Yield.NelsonSiegelSvensson(1.5, 3.0, 0.04, -0.02, 0.03, 0.015)
         for t in (0.5, 2.0, 7.3, 25.0)
-            @test Yield.instantaneous_forward(nss, t) ≈ fd(nss, t) atol = 1.0e-6
+            @test ifwd(nss, t) ≈ fd(nss, t) atol = 1.0e-6
         end
-        @test Yield.instantaneous_forward(nss, 0.0) ≈ 0.04 - 0.02
+        @test ifwd(nss, 0.0) ≈ 0.04 - 0.02
     end
 
     @testset "Spline-backed ZeroRateCurve" begin
@@ -34,13 +44,13 @@
             zrc = ZeroRateCurve(zs, tenors, sp)
             # off-knot points (Linear has kinks at knots where f is undefined)
             for t in (1.5, 3.7, 8.0)
-                @test Yield.instantaneous_forward(zrc, t) ≈ fd(zrc, t) atol = 1.0e-5
+                @test ifwd(zrc, t) ≈ fd(zrc, t) atol = 1.0e-5
             end
         end
 
         # MonotoneConvex-backed (default) delegates to the Hagan–West forward
         zrc_mc = ZeroRateCurve(zs, tenors)
-        @test Yield.instantaneous_forward(zrc_mc, 3.0) ≈ fd(zrc_mc, 3.0) atol = 1.0e-5
+        @test ifwd(zrc_mc, 3.0) ≈ fd(zrc_mc, 3.0) atol = 1.0e-5
 
         @test_throws DomainError Yield.instantaneous_forward(zrc_mc, -1.0)
     end
@@ -51,19 +61,18 @@
         ns = Yield.NelsonSiegel(3.0, 0.04, -0.02, 0.03)
 
         # CompositeYield: forwards add/subtract for the +/− compositions
-        @test Yield.instantaneous_forward(a + b, 2.0) ≈
-            Yield.instantaneous_forward(a, 2.0) + Yield.instantaneous_forward(b, 2.0)
-        @test Yield.instantaneous_forward(ns - b, 2.0) ≈ fd(ns - b, 2.0) atol = 1.0e-6
+        @test ifwd(a + b, 2.0) ≈ ifwd(a, 2.0) + ifwd(b, 2.0)
+        @test ifwd(ns - b, 2.0) ≈ fd(ns - b, 2.0) atol = 1.0e-6
 
         # ScaledYield: forward scales with the curve
         m = Yield.Constant(Continuous(0.05)) * 0.79
-        @test Yield.instantaneous_forward(m, 2.0) ≈ 0.05 * 0.79
-        @test Yield.instantaneous_forward(ns * 2.0, 4.0) ≈ fd(ns * 2.0, 4.0) atol = 1.0e-6
+        @test ifwd(m, 2.0) ≈ 0.05 * 0.79
+        @test ifwd(ns * 2.0, 4.0) ≈ fd(ns * 2.0, 4.0) atol = 1.0e-6
 
         # ForwardStarting: forward is the base curve's forward shifted by the start
         fs = Yield.ForwardStarting(ns, 1.0)
-        @test Yield.instantaneous_forward(fs, 2.0) ≈ Yield.instantaneous_forward(ns, 3.0)
-        @test Yield.instantaneous_forward(fs, 2.0) ≈ fd(fs, 2.0) atol = 1.0e-6
+        @test ifwd(fs, 2.0) ≈ ifwd(ns, 3.0)
+        @test ifwd(fs, 2.0) ≈ fd(fs, 2.0) atol = 1.0e-6
     end
 
     @testset "discount-native models error rather than approximate" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,7 @@ include("NelsonSiegelSvensson.jl")
 include("CairnsPritchard.jl")
 include("MonotoneConvex.jl")
 include("ZeroRateCurve.jl")
+include("instantaneous_forward.jl")
 include("regressions.jl")
 
 include("extensions.jl")


### PR DESCRIPTION
## Summary

`instantaneous_forward` is exported from the `Yield` module but was only defined for `MonotoneConvex` — `Yield.instantaneous_forward(Yield.Constant(0.03), 2.0)` threw a `MethodError`. This PR adds methods everywhere the instantaneous forward `f(t) = ∂/∂t(−log P(t)) = z(t) + t·z′(t)` has an analytic form:

| Model | Method |
|---|---|
| `Constant` | the continuous rate itself |
| `Spline` | `z(t) + t·z′(t)` via `DataInterpolations.derivative` |
| `NelsonSiegel` / `NelsonSiegelSvensson` | closed forms (`f(t) = β₀ + β₁e^{−t/τ₁} + β₂(t/τ₁)e^{−t/τ₁} [+ β₃(t/τ₂)e^{−t/τ₂}]`); `f(0) = β₀+β₁` matches `zero`'s t=0 limit |
| `ZeroRateCurve` | delegates to its prebuilt interpolation model (Spline or MonotoneConvex), with the same `t ≥ 0` domain check as `discount` |
| `CompositeYield` | `op(f₁, f₂)` — defined only for `typeof(+)`/`typeof(-)` (the ops the public constructors create), where composition in zero space composes forwards exactly |
| `ScaledYield` | `factor · f_base` |
| `ForwardStarting` | `f_base(t + forwardstart)` |

**Return convention: a `Continuous` `Rate`.** The instantaneous forward is by definition continuously compounded, and returning a `Rate` keeps it consistent with `zero`/`forward`/`par` and composable with `discount`/`accumulation`. Internally each model defines a raw-scalar `_instantaneous_forward` kernel and a single public method wraps the result in `Continuous`, so the wrapper arithmetic (`+`/`-`, scaling) stays in plain floats.

This changes the pre-existing `MonotoneConvex` method, which returned a bare `Real`. That method shipped in v6.1.0 (2026-06-13), is exported only from the `Yield` submodule, and has no observable downstream consumers (nothing in JuliaActuary; a GitHub-wide search finds only unrelated same-named functions) — so the inconsistency is treated as a fix here rather than a breaking change, with a migration-guide entry. Relates to the API taxonomy discussion in #272.

A generic function docstring documents the contract and the deliberate non-goal: discount-native models (`SmithWilson`, the short-rate models) **still throw `MethodError`** rather than silently falling back to a numerical approximation.

## Changes

- `src/model/Yield.jl`: generic docstring + public `Continuous`-wrapping method + `Constant`/`Spline`/wrapper kernels
- `src/model/Yield/NelsonSiegelSvensson.jl`: NS/NSS closed-form kernels
- `src/model/Yield/ZeroRateCurve.jl`: delegation kernel
- `src/model/Yield/MonotoneConvex.jl`: existing method becomes the `_instantaneous_forward` kernel
- `docs/src/migration.md`: v6.2 → v6.3 entry for the return-type change
- `test/instantaneous_forward.jl` (new, wired into runtests): every method validated against central finite differences of `−log P(t)`, plus wrapper identities, `f(0)` limits, `Rate` return/composability, domain error, and the SmithWilson `MethodError` contract
- `test/MonotoneConvex.jl`: forward-value assertions unwrap via a `rate(...)` helper
- `Project.toml`: 6.2.0 → 6.3.0

## Test plan

- [x] Full test suite passes locally (35 new tests; all 2900+ existing pass, against registered FinanceCore 2.5.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
