### PR TITLE
zero(model, 0): throw DomainError instead of returning Continuous(NaN) (v6.2.1)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceModels"
 uuid = "77f2ae65-bdde-421f-ae9d-22f1af19dd76"
-version = "6.2.0"
+version = "6.2.1"
 authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
 
 [deps]

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -210,8 +210,24 @@ end
     zero(curve,time)
 
 Return the zero rate for the curve at the given time.
+
+At `time == 0` the generic definition `-log(discount(curve, t)) / t` is `0/0`; models
+whose zero rate has an analytic `t → 0` limit (e.g. `Constant`, `Spline`,
+`NelsonSiegel(-Svensson)`, `MonotoneConvex`) define their own method for it, and models
+without one throw a `DomainError` rather than returning `Continuous(NaN)`.
 """
 function Base.zero(c::YC, time) where {YC <: AbstractYieldModel}
+    # -log(df)/t is 0/0 at t = 0. Returning the NaN would silently poison anything
+    # computed from it downstream, so error loudly instead. The t → 0 limit is the
+    # instantaneous forward at 0; models with an analytic limit define their own method.
+    iszero(time) && throw(
+        DomainError(
+            time,
+            "The zero rate of a $(nameof(YC)) is not defined at t = 0 by the generic " *
+                "-log(discount(curve, t)) / t (which is 0/0 there). Evaluate at a small t > 0, " *
+                "or use a model type that defines the analytic t → 0 limit."
+        )
+    )
     df = discount(c, time)
     r = -log(df) / time
     return Continuous(r)

--- a/test/Yield.jl
+++ b/test/Yield.jl
@@ -675,3 +675,23 @@ end
     end
 
 end
+
+@testset "zero(model, 0) errors loudly instead of returning NaN" begin
+    # models with an analytic t → 0 limit keep their own methods
+    @test FinanceCore.rate(zero(Yield.Constant(0.03), 0)) ≈ log(1.03)
+    ns = Yield.NelsonSiegel(3.0, 0.04, -0.02, 0.03)
+    @test FinanceCore.rate(zero(ns, 0.0)) ≈ 0.04 - 0.02
+
+    # models served by the generic -log(discount)/t fallback returned
+    # Continuous(NaN) at t = 0; that NaN silently poisoned downstream math.
+    sw = Yield.SmithWilson([1.0, 2.0], [0.1, 0.2]; ufr = 0.03, α = 0.1)
+    zrc = ZeroRateCurve([0.02, 0.03], [1.0, 5.0])
+    fs = Yield.ForwardStarting(Yield.Constant(0.03), 1.0)
+    for m in (sw, zrc, fs)
+        @test_throws DomainError zero(m, 0)
+        @test_throws DomainError zero(m, 0.0)
+        # nonzero times are unaffected
+        @test FinanceCore.rate(zero(m, 1.0)) isa Real
+        @test !isnan(FinanceCore.rate(zero(m, 1.0)))
+    end
+end


### PR DESCRIPTION
## Summary

The generic `Base.zero(::AbstractYieldModel, t)` fallback computes `-log(discount(curve, t)) / t`, which is `0/0` at `t = 0`. Models that rely on the fallback returned `Continuous(NaN)` silently:

```julia
julia> sw = Yield.SmithWilson([1.0, 2.0], [0.1, 0.2]; ufr = 0.03, α = 0.1);

julia> zero(sw, 0.0)
Continuous(NaN)   # ← silently poisons all downstream math
```

Affected models: `SmithWilson`, the short-rate models, `ZeroRateCurve`, `ForwardStarting` — anything without its own `zero` method. Models with an analytic `t → 0` limit (`Constant`, `Spline`, `NelsonSiegel(-Svensson)`, `MonotoneConvex`, `CairnsPritchard`, the shift/composite wrappers over them) define their own methods and are unaffected.

The generic fallback now throws an informative `DomainError` at `t = 0` instead. This follows the same fail-loud-over-NaN principle as the earlier audit fixes (and `ZeroRateCurve`'s constructor already declares the zero rate undefined at `t = 0`).

## Notes

- `discount`, `accumulation`, and `forward` at `t = 0` are unaffected — they guard or special-case zero themselves.
- A possible follow-up: give the short-rate models their analytic limits (`zero(m, 0) = r₀` for Vasicek/CIR, `f(0)` for Hull-White), and once #278 (generic `instantaneous_forward`) lands, the two could be unified (`zero(m, 0) = Continuous(instantaneous_forward(m, 0))` where defined). Kept out of scope here.

## Changes

- `src/model/Yield.jl`: `iszero(time)` guard + expanded docstring on the generic `zero`
- `test/Yield.jl`: testset covering the error for fallback models (`Int` and `Float64` zero), unchanged analytic-limit models, and unaffected `t > 0` behavior
- `Project.toml`: 6.2.0 → 6.2.1 (adjust per merge order — #274/#277 also claim patch bumps)

## Test plan

- [x] Full test suite passes locally against registered FinanceCore (14 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)