### PR TITLE
Add FX module: covered-interest-parity forward curves, contracts, and quote conventions (v6.3.0)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceModels"
 uuid = "77f2ae65-bdde-421f-ae9d-22f1af19dd76"
-version = "6.2.0"
+version = "6.3.0"
 authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Commonly, we deal with conventions that imply a contract and an observed price. 
 - `ParYield`
 - `ParSwapYield`
 - `ForwardYield`
-- `FX.Outright` and `FX.ForwardPoints` (foreign-exchange forwards)
+- `FX.Outright` (foreign-exchange forwards)
 - `FX.ParBasisSwap` (par cross-currency basis-swap spreads, for calibrating the long-dated basis)
 
 FinanceModels offers a way to define new contracts as well.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Existing `struct`s:
 - `Option.EuroCall` and `Option.EuroPut`
 - `CommonEquity`
 - `Option.Cap`, `Option.Floor`, `Option.Swaption` (interest rate derivatives)
+- `FX.Forward` (an outright foreign-exchange forward)
 
 Commonly, we deal with conventions that imply a contract and an observed price. For example, we may talk about a treasury yield of `0.03`. This is a description that implies a `Quote`ed price for an underling fixed bond. In FinanceModels, we could use `CMTYield(rate,tenor)` which would create a `Quote(price,Bond.Fixed(...))`. In this way, we can conveniently create a number of `Quote`s which can be used to fit models. Such convenience methods include:
 
@@ -76,6 +77,7 @@ Commonly, we deal with conventions that imply a contract and an observed price. 
 - `ParYield`
 - `ParSwapYield`
 - `ForwardYield`
+- `FX.Outright` and `FX.ForwardPoints` (foreign-exchange forwards)
 
 FinanceModels offers a way to define new contracts as well.
 
@@ -104,6 +106,10 @@ Stochastic models include:
 
 - `ShortRate.Vasicek`, `ShortRate.CoxIngersollRoss`, and `ShortRate.HullWhite` short-rate models
 - `Equity.BlackScholesMerton` for option valuation
+
+Foreign exchange models include:
+
+- `FX.Forwards` — covered-interest-parity forward exchange rates from a spot rate and a discount curve per currency, fit to forward/points quotes (see the Foreign Exchange docs page)
 
 #### Yield-related functions
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Existing `struct`s:
 - `CommonEquity`
 - `Option.Cap`, `Option.Floor`, `Option.Swaption` (interest rate derivatives)
 - `FX.Forward` (an outright foreign-exchange forward)
+- `FX.Converted` (a contract's cashflows converted into another currency at forward FX rates, e.g. for cross-currency swaps)
 
 Commonly, we deal with conventions that imply a contract and an observed price. For example, we may talk about a treasury yield of `0.03`. This is a description that implies a `Quote`ed price for an underling fixed bond. In FinanceModels, we could use `CMTYield(rate,tenor)` which would create a `Quote(price,Bond.Fixed(...))`. In this way, we can conveniently create a number of `Quote`s which can be used to fit models. Such convenience methods include:
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Commonly, we deal with conventions that imply a contract and an observed price. 
 - `ParSwapYield`
 - `ForwardYield`
 - `FX.Outright` and `FX.ForwardPoints` (foreign-exchange forwards)
+- `FX.ParBasisSwap` (par cross-currency basis-swap spreads, for calibrating the long-dated basis)
 
 FinanceModels offers a way to define new contracts as well.
 
@@ -110,7 +111,7 @@ Stochastic models include:
 
 Foreign exchange models include:
 
-- `FX.Forwards` — covered-interest-parity forward exchange rates from a spot rate and a discount curve per currency, fit to forward/points quotes (see the Foreign Exchange docs page)
+- `FX.Forwards` — covered-interest-parity forward exchange rates from a spot rate and a discount curve per currency, fit to forward/points quotes and/or par basis-swap spreads (see the Foreign Exchange docs page)
 
 #### Yield-related functions
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,6 +21,7 @@ makedocs(;
             "Contracts" => "contracts.md",
             "Rates" => "Rates.md",
             "Yield Curve Arithmetic" => "yield_arithmetic.md",
+            "Foreign Exchange" => "fx.md",
             "Migration Guide" => "migration.md",
         ],
         "Modules" => [
@@ -31,6 +32,7 @@ makedocs(;
             "Yield" => "API/Yield.md",
             "Bond" => "API/Bond.md",
             "Equity" => "API/Equity.md",
+            "FX" => "API/FX.md",
             "Option" => "API/Option.md",
             "Volatility" => "API/Volatility.md",
             "ShortRate" => "API/ShortRate.md",

--- a/docs/src/API/FX.md
+++ b/docs/src/API/FX.md
@@ -1,0 +1,21 @@
+# FinanceModels.FX API Reference
+
+```@index
+Modules = [FinanceModels.FX]
+```
+
+## Exported API
+
+```@autodocs
+Modules = [FinanceModels.FX]
+Private = false
+```
+
+## Unexported API
+
+```@autodocs
+Modules = [FinanceModels.FX]
+Public = false
+```
+
+Please [open an issue](https://github.com/JuliaActuary/FinanceModels.jl/issues) if you encounter any issues or confusion with the package.

--- a/docs/src/fx.md
+++ b/docs/src/fx.md
@@ -47,8 +47,11 @@ returning a wrong number.
 
 Forward *points* are the second convention trap. The interbank market quotes forwards as
 pips over spot, and the pip size differs by pair: `0.0001` for most pairs but `0.01` for
-JPY-quoted pairs. [`FX.ForwardPoints`](@ref) therefore takes the scale explicitly rather
-than guessing (see below).
+JPY-quoted pairs. There is deliberately no points constructor: a function that guessed
+the scale would be the classic silent JPY error, and one that required it would only
+rename the arithmetic. Convert points explicitly at the data boundary, where the
+pair-dependent pip factor stays visible at the call site:
+`FX.Outright.(pair, spot .+ points ./ 10_000, times)`.
 
 ## Covered interest parity
 
@@ -111,8 +114,9 @@ bond quoting at 1.0:
 ```julia
 quotes = FX.Outright.(eurusd, [1.1055, 1.1113, 1.1225, 1.1459], [0.25, 0.5, 1.0, 2.0])
 
-# equivalently, from points over spot (pips; scale is required: 10_000 here, 100 for JPY quotes):
-quotes = FX.ForwardPoints.(eurusd, [55.0, 113.0, 225.0, 459.0], [0.25, 0.5, 1.0, 2.0]; spot = 1.10, scale = 10_000)
+# equivalently, from screen points over spot (pips: 1/10_000 here, 1/100 for JPY quotes):
+points = [55.0, 113.0, 225.0, 459.0]
+quotes = FX.Outright.(eurusd, 1.10 .+ points ./ 10_000, [0.25, 0.5, 1.0, 2.0])
 ```
 
 ## Constructing a curve from market quotes
@@ -288,8 +292,8 @@ estr = ...   # EUR projection curve, fitted from EUR OIS quotes
 sofr = ...   # USD discount curve
 
 quotes = [
-    # short end: forward points
-    FX.ForwardPoints.(eurusd, [25.0, 55.0, 120.0], [0.25, 0.5, 1.0]; spot = 1.10, scale = 10_000);
+    # short end: outrights from screen points over spot (pips = 1/10_000)
+    FX.Outright.(eurusd, 1.10 .+ [25.0, 55.0, 120.0] ./ 10_000, [0.25, 0.5, 1.0]);
     # long end: par basis-swap spreads
     FX.ParBasisSwap.(eurusd, [-0.0012, -0.0015, -0.0018], [2.0, 5.0, 10.0]; reference = estr)
 ]

--- a/docs/src/fx.md
+++ b/docs/src/fx.md
@@ -313,6 +313,21 @@ Deliberately *not* built yet: the mark-to-market (resetting-notional) basis-swap
 *contract* itself, pending convention decisions (which leg resets, settlement timing,
 accrual on the adjustment). Open an issue if your use case needs it sooner.
 
+Also deliberately deferred: **multi-pair consistency**. Each `FX.Forwards` is a
+self-contained model of one pair, and independently fitted pair models are not forced
+to be mutually consistent — nothing makes a directly fitted EURJPY model agree with the
+EURJPY forwards implied by triangulating EURUSD × USDJPY, and each fit implies its own
+version of any shared currency's discount curve. The scaling design is a per-currency
+(*collateral-consistent*) market object: pick one numéraire/collateral currency, store
+one spot rate and one collateral-consistent discount curve per currency, and *derive*
+every pair's forwards from those. For ``N`` currencies that is ``N`` curves instead of
+up to ``N(N-1)/2`` independent pair models, and triangle consistency holds by
+construction rather than by calibration. The tradeoff is exact repricing: where the
+market quotes a direct cross basis inconsistent with triangulation, such a model
+reprices the cross at its derived arbitrage-consistent forward, not at the screen
+quote. `FX.Forwards` is the two-currency case of that design and would become the
+pairwise view a market object returns, so nothing in the current API forecloses it.
+
 ## Relationship to other models
 
 - **FX options**: the Garman–Kohlhagen formula is `Equity.BlackScholesMerton(r_domestic,

--- a/docs/src/fx.md
+++ b/docs/src/fx.md
@@ -249,10 +249,60 @@ basis_swap = Composite(
 principal exchange at maturity is represented; a par basis swap's initial exchange nets
 against a unit `Cashflow` at time zero if you need it explicitly.)
 
-Deliberately *not* built yet, pending convention decisions: mark-to-market (resetting-
-notional) basis swaps, and par-basis-swap `Quote` constructors for calibrating the
-long-dated basis directly from swap quotes — forward-points quotes cover the liquid short
-end today. Open an issue if your use case needs these sooner.
+### Calibrating the long-dated basis from par basis-swap quotes
+
+Forward points cover the liquid short end (out to a year or two); beyond that the
+cross-currency basis trades as **par basis-swap spreads** — "5y EUR/USD basis −18bp"
+means the five-year swap of €STR − 18bp against SOFR flat, with notional exchanges,
+prices to par. [`FX.ParBasisSwap`](@ref) turns those quotes into `fit` inputs.
+
+The quoting assumption, standard for collateralized (OIS-discounted) swaps, is that the
+domestic leg pays the forwards of the same curve used for domestic discounting, so it is
+worth par and drops out. What remains is a condition on the foreign side alone:
+
+```math
+\sum_i (f_i + b)\,\delta\,DF_f(t_i) + DF_f(T) = 1
+```
+
+where ``f_i`` are forwards from the foreign *projection* curve (e.g. a fitted €STR
+curve — a known input passed as the `reference` keyword), ``b`` is the quoted spread,
+``\delta`` the accrual fraction, and ``DF_f`` the basis-adjusted discount curve being
+calibrated. Because the coupon amounts are fully determined by the projection curve,
+each quote materializes into a deterministic base-currency cashflow strip
+([`FX.BasisSwapLeg`](@ref)) that must price to par on the curve being fit — and
+deterministic strips flow through the same fitting machinery as the implied zero-coupon
+quotes. One `fit` call takes both quote types:
+
+```julia
+estr = ...   # EUR projection curve, fitted from EUR OIS quotes
+sofr = ...   # USD discount curve
+
+quotes = [
+    # short end: forward points
+    FX.ForwardPoints.(eurusd, [25.0, 55.0, 120.0], [0.25, 0.5, 1.0]; spot = 1.10);
+    # long end: par basis-swap spreads
+    FX.ParBasisSwap.(eurusd, [-0.0012, -0.0015, -0.0018], [2.0, 5.0, 10.0]; reference = estr)
+]
+
+m = fit(FX.Forwards(eurusd, 1.10, sofr, Spline.Linear()), quotes, Fit.Bootstrap())
+```
+
+Every quote — outright or swap — reprices under the fitted model, and the composite
+basis swap from the previous section values to zero against it (the test suite asserts
+both). Two practical notes:
+
+- Prefer *local* interpolation (e.g. `Spline.Linear`) when bootstrapping coupon-bearing
+  quotes: a global spline reshapes earlier segments as later knots are added, drifting
+  already-solved swaps off par.
+- Interbank basis swaps are quoted on the mark-to-market (resetting-notional)
+  structure. Under deterministic curves the constant-notional and MTM par spreads agree
+  to first order, so quoted spreads calibrate the constant-notional representation
+  directly; the difference only becomes material alongside FX–rates correlation, i.e.
+  with a stochastic FX model.
+
+Deliberately *not* built yet: the mark-to-market (resetting-notional) basis-swap
+*contract* itself, pending convention decisions (which leg resets, settlement timing,
+accrual on the adjustment). Open an issue if your use case needs it sooner.
 
 ## Relationship to other models
 

--- a/docs/src/fx.md
+++ b/docs/src/fx.md
@@ -193,13 +193,15 @@ the contract's cashflows, convert each into the domestic currency, then discount
 usual. [`FX.Converted`](@ref) is that conversion as a wrapper contract. It multiplies
 each projected amount by the CIP forward for that cashflow's time, looking the FX model
 up from the projection's model store by key — the same key/value pattern
-[`Bond.Floating`](@ref FinanceModels.Bond.Floating) uses for its reference rate:
+[`Bond.Floating`](@ref FinanceModels.Bond.Floating) uses for its reference rate. The
+wrapper also carries the pair it expects, so a wrong-direction model under the key — an
+inverted model would silently multiply by reciprocal rates — errors by name instead:
 
 ```julia
 store = Dict("EURUSD" => m, "ESTR" => eur)
 eur_bond = Bond.Fixed(0.04, Periodic(1), 2.0)  # a EUR-denominated bond
 
-p = Projection(FX.Converted(eur_bond, "EURUSD"), store, CashflowProjection())
+p = Projection(FX.Converted(eur_bond, eurusd, "EURUSD"), store, CashflowProjection())
 collect(p)  # USD cashflows: each EUR amount × forward(m, t)
 ```
 
@@ -228,7 +230,7 @@ jpy4 = Yield.Constant(Continuous(0.04))
 fx = FX.Forwards(jpyusd, 1 / 110, usd9, jpy4)
 
 swap = Composite(
-    FX.Converted(Bond.Fixed(0.05, Periodic(1), 3) |> Map(cf -> cf * 1200.0), "JPYUSD"), # receive ¥ leg
+    FX.Converted(Bond.Fixed(0.05, Periodic(1), 3) |> Map(cf -> cf * 1200.0), jpyusd, "JPYUSD"), # receive ¥ leg
     Bond.Fixed(0.08, Periodic(1), 3) |> Map(cf -> cf * -10.0),                          # pay $ leg
 )
 
@@ -254,7 +256,7 @@ floating-for-floating cross-currency basis swap is also just a `Composite`:
 store = Dict("SOFR" => usd_ois, "ESTR" => eur_ois, "EURUSD" => m)
 
 basis_swap = Composite(
-    FX.Converted(Bond.Floating(-0.0020, Periodic(4), 5.0, "ESTR"), "EURUSD"), # receive €STR − 20bp, in USD terms
+    FX.Converted(Bond.Floating(-0.0020, Periodic(4), 5.0, "ESTR"), eurusd, "EURUSD"), # receive €STR − 20bp, in USD terms
     Bond.Floating(0.0, Periodic(4), 5.0, "SOFR") |> Map(-),                   # pay SOFR flat
 )
 ```

--- a/docs/src/fx.md
+++ b/docs/src/fx.md
@@ -1,0 +1,135 @@
+# Foreign Exchange
+
+The [`FX`](@ref FinanceModels.FX) module extends the contracts/models/`fit` architecture to
+currencies. The design observation is that under covered interest parity (CIP), an FX
+forward curve is a *ratio of discount factors* scaled by spot:
+
+```math
+F(t) = S_0 \cdot \frac{DF_{\text{foreign}}(t)}{DF_{\text{domestic}}(t)}
+```
+
+so FX needs no new curve mathematics — every spline, parametric model, bootstrap, and
+piece of curve arithmetic in FinanceModels applies to FX curve construction unchanged.
+What the module adds is the *semantic* layer where FX errors actually happen: explicit
+pair direction, explicit points scale, and loud failures on mismatched currencies.
+
+## Currency pairs
+
+A currency pair is a type-level object. `FX.Pair(:EUR, :USD)` is the market's "EURUSD":
+the price of one unit of the *base* currency (EUR) in units of the *quote* (domestic)
+currency (USD). `inv` flips the direction:
+
+```julia
+eurusd = FX.Pair(:EUR, :USD)
+inv(eurusd) # FX.Pair(:USD, :EUR)
+```
+
+Because the pair travels in the type, pricing a contract against a model quoted in a
+different pair (including the inverted one) is an immediate `ArgumentError` naming both
+pairs — not a silently crossed rate.
+
+## The forward curve model
+
+[`FX.Forwards`](@ref) holds the spot rate and the two discount curves. Any yield model
+works for either curve:
+
+```julia
+using FinanceModels
+
+usd = Yield.Constant(Continuous(0.05))
+eur = Yield.Constant(Continuous(0.03))
+
+m = FX.Forwards(eurusd, 1.10, usd, eur)
+
+forward(m, 0.0) # 1.10 — the spot
+forward(m, 1.0) # 1.10 * exp(0.05 - 0.03) ≈ 1.1222 — CIP forward
+m(1.0)          # callable shorthand for forward(m, 1.0)
+
+mi = inv(m)     # the USDEUR model: forward(mi, t) == 1 / forward(m, t)
+```
+
+An outright forward contract and its valuation (in the quote currency):
+
+```julia
+c = FX.Forward(eurusd, 1.1222, 1.0)  # receive 1 EUR, pay 1.1222 USD, at t = 1
+present_value(m, c)                  # (forward(m, 1) - 1.1222) * discount(usd, 1)
+```
+
+## Building a curve from market quotes
+
+FX forwards are quoted either as outrights or as points over spot. Both return zero-price
+`Quote`s (entering a forward at the market rate costs nothing, just as a par bond quotes
+at 1.0):
+
+```julia
+quotes = FX.Outright.(eurusd, [1.1055, 1.1113, 1.1225, 1.1459], [0.25, 0.5, 1.0, 2.0])
+
+# or, from points (note the explicit pip scale — 10_000 for most pairs, 100 for JPY quotes):
+quotes = FX.ForwardPoints.(eurusd, [55.0, 113.0, 225.0, 459.0], [0.25, 0.5, 1.0, 2.0]; spot = 1.10)
+```
+
+Given spot and the domestic curve, each forward quote pins the implied foreign discount
+factor *in closed form*: ``DF_f(t) = F(t) \cdot DF_d(t) / S_0``. Curve construction is
+therefore just a quote transformation followed by the ordinary fitting machinery, and the
+one-step `fit` methods do exactly that:
+
+```julia
+m = fit(FX.Forwards(eurusd, 1.10, usd, Spline.Cubic()), quotes, Fit.Bootstrap())
+
+forward(m, 1.0)                       # ≈ 1.1225: every quote reprices exactly
+present_value(m, quotes[3].instrument) # ≈ 0.0
+```
+
+The intermediate transform is also available directly via
+[`FX.implied_zcb_quotes`](@ref), which returns zero-coupon `Quote`s you can feed to any
+model — a parametric curve, a different spline, `Fit.Loss` least squares, etc.
+
+Parametric foreign curves fit through the generic optimizer path (the foreign curve's
+parameters are the free variables; spot and the domestic curve are inputs):
+
+```julia
+m = fit(FX.Forwards(eurusd, 1.10, usd, Yield.Constant()), quotes)
+```
+
+## Cross-currency basis and hedge pricing
+
+Since 2008, covered interest parity does not hold against "textbook" curves: market
+forwards embed a cross-currency basis. The model handles this structurally, because the
+`foreign` field is *defined by what reprices the FX market*, not as any particular
+reference curve:
+
+- **Absorbed basis.** When you `fit` an `FX.Forwards` to market forward quotes, the
+  fitted `foreign` curve is the basis-adjusted (CSA / collateralized) discount curve —
+  ``DF_f(t) = F_{\text{mkt}}(t) \cdot DF_d(t) / S_0`` by construction. Anything you then
+  price with the model (forwards, hedged cashflow conversion) is basis-consistent
+  automatically: the cost or benefit of the hedge is embedded in the curve.
+
+- **Explicit basis.** Because curve arithmetic composes in zero-rate space, the basis is
+  a first-class object when you want it to be:
+
+  ```julia
+  # from an OIS curve and a fitted basis spread curve:
+  m = FX.Forwards(eurusd, 1.10, usd_ois, eur_ois + basis)
+
+  # or extract the basis implied by the market-fit model:
+  basis = m_fit.foreign - eur_ois
+  ```
+
+  A ``-20``bp EUR basis (`basis = Yield.Constant(Continuous(-0.002))`) lowers the
+  effective EUR discounting rate and raises the CIP forwards, exactly as quoted markets
+  do.
+
+Long-dated basis calibration from cross-currency *swap* quotes (rather than forward
+points) requires projecting floating legs in two currencies and is planned alongside the
+multi-currency projection wrapper — see the roadmap note below.
+
+## Relationship to other models
+
+- **FX options**: the Garman–Kohlhagen model is `Equity.BlackScholesMerton(r_domestic,
+  r_foreign, σ)` applied to one unit of base currency — the foreign rate plays the role
+  of the dividend yield. Direct pricing methods for `FX` types and delta-conventioned
+  volatility quotes are future work.
+- **Multi-currency projection**: a wrapper contract that converts a foreign contract's
+  projected cashflows at CIP forwards (enabling cross-currency swaps and hedged-portfolio
+  valuation through the `Projection` model store) is the planned next step; `FX.Forwards`
+  is the primitive it consumes.

--- a/docs/src/fx.md
+++ b/docs/src/fx.md
@@ -16,10 +16,10 @@ failures on mismatches.
 
 ## Conventions: pairs, direction, and points
 
-A currency pair is a type-level object created with [`FX.Pair`](@ref). The first symbol
-is the **base** currency (the thing being priced — one unit of it), the second is the
-**quote** (also called *domestic*, *terms*, or *counter*) currency (the units the price
-is expressed in). This matches the market's concatenated naming:
+A currency pair is created with [`FX.Pair`](@ref). The first currency is the **base**
+(the thing being priced — one unit of it), the second is the **quote** (also called
+*domestic*, *terms*, or *counter*) currency (the units the price is expressed in). This
+matches the market's concatenated naming:
 
 | Pair                  | Market name | A rate of | means                |
 |:----------------------|:------------|:----------|:---------------------|
@@ -29,20 +29,21 @@ is expressed in). This matches the market's concatenated naming:
 `inv` flips the direction — `inv(FX.Pair(:EUR, :USD)) == FX.Pair(:USD, :EUR)` — and
 correspondingly inverts the rate.
 
-Currencies are usually `Symbol`s, but any value Julia admits as a type parameter works —
-any `isbits` value, such as
-[InlineStrings](https://github.com/JuliaStrings/InlineStrings.jl) codes
-(`FX.Pair(String3("EUR"), String3("USD"))`) or ISO 4217 numeric codes
-(`FX.Pair(978, 840)`). A plain `String` cannot be a type parameter. Distinct parameter
-values are distinct pairs (a `Symbol` pair never matches an inline-string pair, and
-`String3("EUR")` never matches `String7("EUR")`), so pick one convention per system —
-or normalize at the data boundary with `Symbol(code)`.
+Currencies are usually `Symbol`s, but any values work — strings (plain or the
+[InlineStrings](https://github.com/JuliaStrings/InlineStrings.jl) codes CSV readers
+produce) or ISO 4217 numeric codes (`FX.Pair(978, 840)`). Pairs compare by *content*:
+string-typed currencies match whenever their characters do, regardless of storage type
+(`FX.Pair(String3("EUR"), String3("USD")) == FX.Pair("EUR", "USD")`, since
+`AbstractString` equality and hashing are content-based). A `Symbol` pair and a string
+pair are *not* equal, however — pick one convention per system, normalizing at the data
+boundary (e.g. `Symbol.(codes)`) if sources disagree.
 
 Direction confusion is the classic FX bug: an inverted rate is not obviously wrong on
 sight (`0.91` and `1.10` are both plausible EUR/USD numbers), and a crossed pair can pass
-through an entire calculation silently. Because the pair travels in the *type*, pricing a
-contract against a model quoted in a different pair — including the inverted one — throws
-an immediate `ArgumentError` naming both pairs rather than returning a wrong number.
+through an entire calculation silently. Because every FX contract and model carries its
+pair, pricing a contract against a model quoted in a different pair — including the
+inverted one — throws an immediate `ArgumentError` naming both pairs rather than
+returning a wrong number.
 
 Forward *points* are the second convention trap. The interbank market quotes forwards as
 pips over spot, and the pip size differs by pair: `0.0001` for most pairs but `0.01` for
@@ -110,8 +111,8 @@ bond quoting at 1.0:
 ```julia
 quotes = FX.Outright.(eurusd, [1.1055, 1.1113, 1.1225, 1.1459], [0.25, 0.5, 1.0, 2.0])
 
-# equivalently, from points over spot (pips; scale=10_000 default, 100 for JPY quotes):
-quotes = FX.ForwardPoints.(eurusd, [55.0, 113.0, 225.0, 459.0], [0.25, 0.5, 1.0, 2.0]; spot = 1.10)
+# equivalently, from points over spot (pips; scale is required: 10_000 here, 100 for JPY quotes):
+quotes = FX.ForwardPoints.(eurusd, [55.0, 113.0, 225.0, 459.0], [0.25, 0.5, 1.0, 2.0]; spot = 1.10, scale = 10_000)
 ```
 
 ## Constructing a curve from market quotes
@@ -288,7 +289,7 @@ sofr = ...   # USD discount curve
 
 quotes = [
     # short end: forward points
-    FX.ForwardPoints.(eurusd, [25.0, 55.0, 120.0], [0.25, 0.5, 1.0]; spot = 1.10);
+    FX.ForwardPoints.(eurusd, [25.0, 55.0, 120.0], [0.25, 0.5, 1.0]; spot = 1.10, scale = 10_000);
     # long end: par basis-swap spreads
     FX.ParBasisSwap.(eurusd, [-0.0012, -0.0015, -0.0018], [2.0, 5.0, 10.0]; reference = estr)
 ]

--- a/docs/src/fx.md
+++ b/docs/src/fx.md
@@ -315,6 +315,12 @@ both). Two practical notes:
   to first order, so quoted spreads calibrate the constant-notional representation
   directly; the difference only becomes material alongside FX–rates correlation, i.e.
   with a stochastic FX model.
+- A tenor that is not a whole number of coupon periods forms a *short first stub* (the
+  schedule stays anchored at maturity, per `Bond.coupon_times`). The stub coupon
+  accrues its actual length at the forward over `[0, t₁]`, compound-accrued so a
+  zero-spread leg on its own curve stays exactly par — `ParYield`'s stub convention.
+  `Bond.Floating` applies a full-period accrual to stubs, so the
+  strip-equals-projected-leg identity is exact for whole-period tenors.
 
 Deliberately *not* built yet: the mark-to-market (resetting-notional) basis-swap
 *contract* itself, pending convention decisions (which leg resets, settlement timing,

--- a/docs/src/fx.md
+++ b/docs/src/fx.md
@@ -1,90 +1,134 @@
 # Foreign Exchange
 
-The [`FX`](@ref FinanceModels.FX) module extends the contracts/models/`fit` architecture to
-currencies. The design observation is that under covered interest parity (CIP), an FX
-forward curve is a *ratio of discount factors* scaled by spot:
+The [`FX`](@ref FinanceModels.FX) module extends the contracts/models/`fit` architecture
+to currencies. It rests on one observation: under covered interest parity (CIP), an FX
+forward curve is a *ratio of discount factors* scaled by spot,
 
 ```math
 F(t) = S_0 \cdot \frac{DF_{\text{foreign}}(t)}{DF_{\text{domestic}}(t)}
 ```
 
-so FX needs no new curve mathematics — every spline, parametric model, bootstrap, and
+so FX requires no new curve mathematics — every spline, parametric model, bootstrap, and
 piece of curve arithmetic in FinanceModels applies to FX curve construction unchanged.
 What the module adds is the *semantic* layer where FX errors actually happen: explicit
-pair direction, explicit points scale, and loud failures on mismatched currencies.
+pair direction, explicit points scale, explicit currency of every cashflow, and loud
+failures on mismatches.
 
-## Currency pairs
+## Conventions: pairs, direction, and points
 
-A currency pair is a type-level object. `FX.Pair(:EUR, :USD)` is the market's "EURUSD":
-the price of one unit of the *base* currency (EUR) in units of the *quote* (domestic)
-currency (USD). `inv` flips the direction:
+A currency pair is a type-level object created with [`FX.Pair`](@ref). The first symbol
+is the **base** currency (the thing being priced — one unit of it), the second is the
+**quote** (also called *domestic*, *terms*, or *counter*) currency (the units the price
+is expressed in). This matches the market's concatenated naming:
 
-```julia
-eurusd = FX.Pair(:EUR, :USD)
-inv(eurusd) # FX.Pair(:USD, :EUR)
-```
+| Pair                  | Market name | A rate of | means                |
+|:----------------------|:------------|:----------|:---------------------|
+| `FX.Pair(:EUR, :USD)` | EURUSD      | `1.10`    | \$1.10 per €1        |
+| `FX.Pair(:USD, :JPY)` | USDJPY      | `150.0`   | ¥150 per \$1         |
 
-Because the pair travels in the type, pricing a contract against a model quoted in a
-different pair (including the inverted one) is an immediate `ArgumentError` naming both
-pairs — not a silently crossed rate.
+`inv` flips the direction — `inv(FX.Pair(:EUR, :USD)) == FX.Pair(:USD, :EUR)` — and
+correspondingly inverts the rate.
 
-## The forward curve model
+Direction confusion is the classic FX bug: an inverted rate is not obviously wrong on
+sight (`0.91` and `1.10` are both plausible EUR/USD numbers), and a crossed pair can pass
+through an entire calculation silently. Because the pair travels in the *type*, pricing a
+contract against a model quoted in a different pair — including the inverted one — throws
+an immediate `ArgumentError` naming both pairs rather than returning a wrong number.
 
-[`FX.Forwards`](@ref) holds the spot rate and the two discount curves. Any yield model
-works for either curve:
+Forward *points* are the second convention trap. The interbank market quotes forwards as
+pips over spot, and the pip size differs by pair: `0.0001` for most pairs but `0.01` for
+JPY-quoted pairs. [`FX.ForwardPoints`](@ref) therefore takes the scale explicitly rather
+than guessing (see below).
+
+## Covered interest parity
+
+Why must the forward rate equal ``S_0 \cdot DF_f(t)/DF_d(t)``? Compare two ways of
+arranging to hold one unit of the base currency at time ``t``:
+
+1. **Buy now and deposit**: buy ``DF_f(t)`` units of base currency today (cost
+   ``S_0 \cdot DF_f(t)`` in quote currency) and invest them at the base-currency rate;
+   they accumulate to exactly 1 unit at ``t``.
+2. **Deposit and buy forward**: invest ``F(t) \cdot DF_d(t)`` of quote currency at the
+   quote-currency rate (worth ``F(t)`` at ``t``) and contract today, at zero cost, to
+   exchange it for 1 base unit at the forward rate ``F(t)``.
+
+Both strategies deliver the same thing, so they must cost the same today:
+``S_0 \, DF_f(t) = F(t) \, DF_d(t)``, which rearranges to the CIP formula. If the traded
+forward deviates, the difference is a riskless profit ("covered interest arbitrage").
+
+[`FX.Forwards`](@ref) is this equation as a model — a pair, a spot rate, and one discount
+curve per currency, where each curve can be *any* yield model (constant, spline,
+Nelson–Siegel, a `CompositeYield` sum, …):
 
 ```julia
 using FinanceModels
 
+eurusd = FX.Pair(:EUR, :USD)
 usd = Yield.Constant(Continuous(0.05))
 eur = Yield.Constant(Continuous(0.03))
 
 m = FX.Forwards(eurusd, 1.10, usd, eur)
 
-forward(m, 0.0) # 1.10 — the spot
-forward(m, 1.0) # 1.10 * exp(0.05 - 0.03) ≈ 1.1222 — CIP forward
+forward(m, 0.0) # 1.10 — the spot rate
+forward(m, 1.0) # 1.10 * exp(0.05 - 0.03) ≈ 1.1222
 m(1.0)          # callable shorthand for forward(m, 1.0)
 
 mi = inv(m)     # the USDEUR model: forward(mi, t) == 1 / forward(m, t)
 ```
 
-An outright forward contract and its valuation (in the quote currency):
+Note the direction of the effect: the *higher*-rate currency's forwards depreciate — here
+USD rates exceed EUR rates, so EURUSD forwards sit *above* spot (EUR at a forward
+premium). This is exactly Hull's introductory example (*Options, Futures, and Other
+Derivatives*, §5.10): AUD/USD spot 0.6200 with 5% AUD and 7% USD rates gives a 2-year
+forward of ``0.62\,e^{(0.07-0.05)\cdot 2} = 0.6453``, which is reproduced in this
+package's test suite.
+
+## Contracts and quotes
+
+[`FX.Forward`](@ref) is the outright forward contract: at `time`, receive one unit of
+base currency and pay `strike` units of quote currency. Its value, in quote currency, is
+the discounted difference between the model forward and the strike:
 
 ```julia
-c = FX.Forward(eurusd, 1.1222, 1.0)  # receive 1 EUR, pay 1.1222 USD, at t = 1
+c = FX.Forward(eurusd, 1.1222, 1.0)  # receive €1, pay $1.1222, at t = 1
 present_value(m, c)                  # (forward(m, 1) - 1.1222) * discount(usd, 1)
 ```
 
-## Building a curve from market quotes
-
-FX forwards are quoted either as outrights or as points over spot. Both return zero-price
-`Quote`s (entering a forward at the market rate costs nothing, just as a par bond quotes
-at 1.0):
+A forward struck *at* the market rate costs nothing to enter. That is precisely how the
+market quotes forwards, so FX quotes are zero-price `Quote`s — the FX analog of a par
+bond quoting at 1.0:
 
 ```julia
 quotes = FX.Outright.(eurusd, [1.1055, 1.1113, 1.1225, 1.1459], [0.25, 0.5, 1.0, 2.0])
 
-# or, from points (note the explicit pip scale — 10_000 for most pairs, 100 for JPY quotes):
+# equivalently, from points over spot (pips; scale=10_000 default, 100 for JPY quotes):
 quotes = FX.ForwardPoints.(eurusd, [55.0, 113.0, 225.0, 459.0], [0.25, 0.5, 1.0, 2.0]; spot = 1.10)
 ```
 
-Given spot and the domestic curve, each forward quote pins the implied foreign discount
-factor *in closed form*: ``DF_f(t) = F(t) \cdot DF_d(t) / S_0``. Curve construction is
-therefore just a quote transformation followed by the ordinary fitting machinery, and the
-one-step `fit` methods do exactly that:
+## Constructing a curve from market quotes
+
+Set the pricing equation of a quoted forward to its (zero) price and solve: with
+``p = (F(t) - K)\,DF_d(t)`` and ``F(t) = S_0\,DF_f(t)/DF_d(t)``,
+
+```math
+DF_f(t) = \frac{K \cdot DF_d(t) + p}{S_0}
+```
+
+Given spot and the domestic curve, *each forward quote pins the implied foreign discount
+factor in closed form* — no optimizer, no iteration. Curve construction therefore reduces
+to a quote transformation followed by the ordinary fitting machinery, which is what the
+one-step `fit` methods do:
 
 ```julia
 m = fit(FX.Forwards(eurusd, 1.10, usd, Spline.Cubic()), quotes, Fit.Bootstrap())
 
-forward(m, 1.0)                       # ≈ 1.1225: every quote reprices exactly
+forward(m, 1.0)                        # ≈ 1.1225: every quote reprices exactly
 present_value(m, quotes[3].instrument) # ≈ 0.0
 ```
 
-The intermediate transform is also available directly via
-[`FX.implied_zcb_quotes`](@ref), which returns zero-coupon `Quote`s you can feed to any
-model — a parametric curve, a different spline, `Fit.Loss` least squares, etc.
-
-Parametric foreign curves fit through the generic optimizer path (the foreign curve's
+The intermediate transform is available directly as [`FX.implied_zcb_quotes`](@ref),
+returning zero-coupon `Quote`s you can feed to *any* model or fitting method. Parametric
+foreign curves calibrate through the generic optimizer path (the foreign curve's
 parameters are the free variables; spot and the domestic curve are inputs):
 
 ```julia
@@ -93,43 +137,130 @@ m = fit(FX.Forwards(eurusd, 1.10, usd, Yield.Constant()), quotes)
 
 ## Cross-currency basis and hedge pricing
 
-Since 2008, covered interest parity does not hold against "textbook" curves: market
-forwards embed a cross-currency basis. The model handles this structurally, because the
-`foreign` field is *defined by what reprices the FX market*, not as any particular
-reference curve:
+Textbook CIP stopped holding exactly in 2008: regulatory balance-sheet costs and demand
+for dollar funding mean market forwards deviate from the CIP value computed off each
+currency's own OIS curve. The deviation, expressed as a spread on one leg, is the
+**cross-currency basis** (persistently negative vs. USD for EUR and especially JPY in the
+post-crisis era).
+
+The model handles this structurally, because the `foreign` field is *defined by what
+reprices the FX market* rather than as any particular reference curve:
 
 - **Absorbed basis.** When you `fit` an `FX.Forwards` to market forward quotes, the
   fitted `foreign` curve is the basis-adjusted (CSA / collateralized) discount curve —
-  ``DF_f(t) = F_{\text{mkt}}(t) \cdot DF_d(t) / S_0`` by construction. Anything you then
-  price with the model (forwards, hedged cashflow conversion) is basis-consistent
-  automatically: the cost or benefit of the hedge is embedded in the curve.
+  ``DF_f(t) = F_{\text{mkt}}(t) \cdot DF_d(t) / S_0`` by construction. Everything priced
+  with the fitted model — forwards, hedge rolls, converted cashflows — is
+  basis-consistent automatically: the cost or benefit of the currency hedge is embedded
+  in the curve.
 
 - **Explicit basis.** Because curve arithmetic composes in zero-rate space, the basis is
-  a first-class object when you want it to be:
+  a first-class curve when you want to see it:
 
   ```julia
   # from an OIS curve and a fitted basis spread curve:
   m = FX.Forwards(eurusd, 1.10, usd_ois, eur_ois + basis)
 
-  # or extract the basis implied by the market-fit model:
+  # or extract the basis implied by a market-fit model:
   basis = m_fit.foreign - eur_ois
   ```
 
-  A ``-20``bp EUR basis (`basis = Yield.Constant(Continuous(-0.002))`) lowers the
-  effective EUR discounting rate and raises the CIP forwards, exactly as quoted markets
-  do.
+  A ``-20``bp EUR basis (`Yield.Constant(Continuous(-0.002))`) lowers effective EUR
+  discounting and raises the CIP forwards, exactly as quoted markets do.
 
-Long-dated basis calibration from cross-currency *swap* quotes (rather than forward
-points) requires projecting floating legs in two currencies and is planned alongside the
-multi-currency projection wrapper — see the roadmap note below.
+One practical consequence for hedged portfolios: the domestic-equivalent yield curve of a
+fully-hedged foreign asset is `asset_curve - m.foreign + m.domestic` (all zero-rate
+arithmetic) — the asset's spread over the basis-adjusted foreign curve, re-anchored to
+domestic rates. The basis shows up as exactly the hedge drag it is in practice.
+
+## Multi-currency valuation and cross-currency swaps
+
+Valuing a foreign-currency contract in domestic terms is a *projection* concern: project
+the contract's cashflows, convert each into the domestic currency, then discount as
+usual. [`FX.Converted`](@ref) is that conversion as a wrapper contract. It multiplies
+each projected amount by the CIP forward for that cashflow's time, looking the FX model
+up from the projection's model store by key — the same key/value pattern
+[`Bond.Floating`](@ref FinanceModels.Bond.Floating) uses for its reference rate:
+
+```julia
+store = Dict("EURUSD" => m, "ESTR" => eur)
+eur_bond = Bond.Fixed(0.04, Periodic(1), 2.0)  # a EUR-denominated bond
+
+p = Projection(FX.Converted(eur_bond, "EURUSD"), store, CashflowProjection())
+collect(p)  # USD cashflows: each EUR amount × forward(m, t)
+```
+
+Converting at forwards and discounting domestically is *identical* to discounting on the
+(basis-adjusted) foreign curve and converting at spot:
+
+```math
+\sum_t c_t \, F(t) \, DF_d(t) \;=\; S_0 \sum_t c_t \, DF_f(t)
+```
+
+so hedged cross-currency valuation is consistent whichever way it is sliced — this
+identity is asserted directly in the test suite, for fixed and floating legs alike.
+
+### A worked example: Hull's fixed-for-fixed currency swap
+
+The classic currency-swap valuation (Hull, *Options, Futures, and Other Derivatives*,
+§7.9): term structures are flat at 9% in the US and 4% in Japan (continuously
+compounded), spot is ¥110 = \$1, and an institution receives 5% annually on ¥1,200M and
+pays 8% annually on \$10M for three more years, with principals exchanged at maturity.
+A currency swap is just two bonds — one converted:
+
+```julia
+jpyusd = FX.Pair(:JPY, :USD)
+usd9 = Yield.Constant(Continuous(0.09))
+jpy4 = Yield.Constant(Continuous(0.04))
+fx = FX.Forwards(jpyusd, 1 / 110, usd9, jpy4)
+
+swap = Composite(
+    FX.Converted(Bond.Fixed(0.05, Periodic(1), 3) |> Map(cf -> cf * 1200.0), "JPYUSD"), # receive ¥ leg
+    Bond.Fixed(0.08, Periodic(1), 3) |> Map(cf -> cf * -10.0),                          # pay $ leg
+)
+
+p = Projection(swap, Dict("JPYUSD" => fx), CashflowProjection())
+pv(usd9, p) # ≈ 1.5430 ($ millions)
+```
+
+Hull values this swap both as a portfolio of forward contracts (his Table 7.9: forwards
+0.009557, 0.010047, 0.010562 — compare `forward(fx, 1.0)` etc.) and as two bonds
+converted at spot (``1{,}230.55/110 - 9.6439 = 1.543``). The projection above *is* the
+forward-portfolio route; the two-bond route is
+`1200 * pv(jpy4, yen_bond) / 110 - 10 * pv(usd9, usd_bond)`; both give \$1.543M, and the
+test suite asserts they agree to numerical precision.
+
+### Floating legs and basis swaps
+
+Because a converted contract still sees the full model store, a converted
+[`Bond.Floating`](@ref FinanceModels.Bond.Floating) resolves its own reference curve
+while its cashflows are converted — so the market-standard constant-notional
+floating-for-floating cross-currency basis swap is also just a `Composite`:
+
+```julia
+store = Dict("SOFR" => usd_ois, "ESTR" => eur_ois, "EURUSD" => m)
+
+basis_swap = Composite(
+    FX.Converted(Bond.Floating(-0.0020, Periodic(4), 5.0, "ESTR"), "EURUSD"), # receive €STR − 20bp, in USD terms
+    Bond.Floating(0.0, Periodic(4), 5.0, "SOFR") |> Map(-),                   # pay SOFR flat
+)
+```
+
+(The `Bond.Floating` legs are bond-style — they include the final principal — so the
+principal exchange at maturity is represented; a par basis swap's initial exchange nets
+against a unit `Cashflow` at time zero if you need it explicitly.)
+
+Deliberately *not* built yet, pending convention decisions: mark-to-market (resetting-
+notional) basis swaps, and par-basis-swap `Quote` constructors for calibrating the
+long-dated basis directly from swap quotes — forward-points quotes cover the liquid short
+end today. Open an issue if your use case needs these sooner.
 
 ## Relationship to other models
 
-- **FX options**: the Garman–Kohlhagen model is `Equity.BlackScholesMerton(r_domestic,
+- **FX options**: the Garman–Kohlhagen formula is `Equity.BlackScholesMerton(r_domestic,
   r_foreign, σ)` applied to one unit of base currency — the foreign rate plays the role
   of the dividend yield. Direct pricing methods for `FX` types and delta-conventioned
-  volatility quotes are future work.
-- **Multi-currency projection**: a wrapper contract that converts a foreign contract's
-  projected cashflows at CIP forwards (enabling cross-currency swaps and hedged-portfolio
-  valuation through the `Projection` model store) is the planned next step; `FX.Forwards`
-  is the primitive it consumes.
+  volatility quotes (ATM/risk-reversal/butterfly) are future work.
+- **Stochastic FX** (simulated spot paths over correlated short-rate models, for
+  real-world/unhedged projection) would slot into the existing
+  `simulate`/[`RatePath`](@ref FinanceModels.RatePath) machinery and is likewise future
+  work.

--- a/docs/src/fx.md
+++ b/docs/src/fx.md
@@ -11,8 +11,8 @@ F(t) = S_0 \cdot \frac{DF_{\text{foreign}}(t)}{DF_{\text{domestic}}(t)}
 so FX requires no new curve mathematics — every spline, parametric model, bootstrap, and
 piece of curve arithmetic in FinanceModels applies to FX curve construction unchanged.
 What the module adds is the *semantic* layer where FX errors actually happen: explicit
-pair direction, explicit points scale, explicit currency of every cashflow, and loud
-failures on mismatches.
+pair direction, explicit points scale, an explicit currency declaration on every
+contract, and loud failures on mismatches.
 
 ## Conventions: pairs, direction, and points
 
@@ -277,13 +277,13 @@ domestic leg pays the forwards of the same curve used for domestic discounting, 
 worth par and drops out. What remains is a condition on the foreign side alone:
 
 ```math
-\sum_i (f_i + b)\,\delta\,DF_f(t_i) + DF_f(T) = 1
+\sum_i (f_i + b)\,\delta_i\,DF_f(t_i) + DF_f(T) = 1
 ```
 
 where ``f_i`` are forwards from the foreign *projection* curve (e.g. a fitted €STR
 curve — a known input passed as the `reference` keyword), ``b`` is the quoted spread,
-``\delta`` the accrual fraction, and ``DF_f`` the basis-adjusted discount curve being
-calibrated. Because the coupon amounts are fully determined by the projection curve,
+``\delta_i`` the accrual fraction (`1/frequency`, except for a short first stub), and
+``DF_f`` the basis-adjusted discount curve being calibrated. Because the coupon amounts are fully determined by the projection curve,
 each quote materializes into a deterministic base-currency cashflow strip
 ([`FX.BasisSwapLeg`](@ref)) that must price to par on the curve being fit — and
 deterministic strips flow through the same fitting machinery as the implied zero-coupon
@@ -310,11 +310,26 @@ both). Two practical notes:
 - Prefer *local* interpolation (e.g. `Spline.Linear`) when bootstrapping coupon-bearing
   quotes: a global spline reshapes earlier segments as later knots are added, drifting
   already-solved swaps off par.
+- A mixed quote set under `Fit.Loss` (rather than `Fit.Bootstrap`) sums residuals of
+  different scales — discount-factor units for implied zero-coupon quotes, par-price
+  units for basis-swap strips — implicitly weighting the two families differently; the
+  bootstrap solves each quote exactly and involves no such weighting.
 - Interbank basis swaps are quoted on the mark-to-market (resetting-notional)
-  structure. Under deterministic curves the constant-notional and MTM par spreads agree
-  to first order, so quoted spreads calibrate the constant-notional representation
-  directly; the difference only becomes material alongside FX–rates correlation, i.e.
-  with a stochastic FX model.
+  structure, in which the flat domestic leg's notional resets to spot each period while
+  the spread leg's stays constant. Under deterministic curves the constant-notional and
+  MTM par spreads are *exactly* equal — valued at CIP forwards, the resetting leg is a
+  telescoping strip of one-period loans at the domestic curve's own forwards, each
+  worth par, so it drops out period by period just as the constant-notional leg drops
+  out in one step (the test suite asserts the equality to machine precision) — and
+  quoted MTM spreads calibrate the constant-notional representation without
+  approximation. What separates the two structures is a convexity term on the resetting
+  leg that requires *both* an index–discount spread on that leg *and* stochastically
+  correlated FX and rates — identically zero here, where curves are deterministic and
+  the flat leg pays its own discounting curve. This is the standard curve-construction
+  treatment: Fujii, Shimada & Takahashi, *A Note on the Construction of Multiple Swap
+  Curves with and without Collateral* (2010), §3.5, value the MtM leg as a portfolio of
+  one-period swaps and show its value is exactly zero when its index is the discounting
+  rate, with the residual otherwise a covariance term.
 - A tenor that is not a whole number of coupon periods forms a *short first stub* (the
   schedule stays anchored at maturity, per `Bond.coupon_times`). The stub coupon
   accrues its actual length at the forward over `[0, t₁]`, compound-accrued so a

--- a/docs/src/fx.md
+++ b/docs/src/fx.md
@@ -29,6 +29,15 @@ is expressed in). This matches the market's concatenated naming:
 `inv` flips the direction — `inv(FX.Pair(:EUR, :USD)) == FX.Pair(:USD, :EUR)` — and
 correspondingly inverts the rate.
 
+Currencies are usually `Symbol`s, but any value Julia admits as a type parameter works —
+any `isbits` value, such as
+[InlineStrings](https://github.com/JuliaStrings/InlineStrings.jl) codes
+(`FX.Pair(String3("EUR"), String3("USD"))`) or ISO 4217 numeric codes
+(`FX.Pair(978, 840)`). A plain `String` cannot be a type parameter. Distinct parameter
+values are distinct pairs (a `Symbol` pair never matches an inline-string pair, and
+`String3("EUR")` never matches `String7("EUR")`), so pick one convention per system —
+or normalize at the data boundary with `Symbol(code)`.
+
 Direction confusion is the classic FX bug: an inverted rate is not obviously wrong on
 sight (`0.91` and `1.10` are both plausible EUR/USD numbers), and a crossed pair can pass
 through an entire calculation silently. Because the pair travels in the *type*, pricing a

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -242,6 +242,6 @@ A volatility model must extend `volatility(vol::Volatility.MyNewModel, strike_ra
 
 ## Foreign Exchange Models
 
-- [`FinanceModels.FX.Forwards`](@ref) — covered-interest-parity outright forward rates from a spot rate and a discount curve per currency; fit to [`FX.Outright`](@ref FinanceModels.FX.Outright) / [`FX.ForwardPoints`](@ref FinanceModels.FX.ForwardPoints) quotes.
+- [`FinanceModels.FX.Forwards`](@ref) — covered-interest-parity outright forward rates from a spot rate and a discount curve per currency; fit to [`FX.Outright`](@ref FinanceModels.FX.Outright) quotes.
 
 See the [Foreign Exchange](@ref) guide page for pair conventions, curve construction, and cross-currency basis handling.

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -239,3 +239,9 @@ See the [FinanceModels.jl Guide](@ref) for an example of creating a model from s
 #### Creating new Volatility Models
 
 A volatility model must extend `volatility(vol::Volatility.MyNewModel, strike_ratio, time_to_maturity)`.
+
+## Foreign Exchange Models
+
+- [`FinanceModels.FX.Forwards`](@ref) — covered-interest-parity outright forward rates from a spot rate and a discount curve per currency; fit to [`FX.Outright`](@ref FinanceModels.FX.Outright) / [`FX.ForwardPoints`](@ref FinanceModels.FX.ForwardPoints) quotes.
+
+See the [Foreign Exchange](@ref) guide page for pair conventions, curve construction, and cross-currency basis handling.

--- a/src/FinanceModels.jl
+++ b/src/FinanceModels.jl
@@ -40,6 +40,7 @@ using .Yield: par
 export par
 
 export Equity, Volatility
+export FX
 export ShortRate, AbstractStochasticModel, RatePath, simulate, pv_mc, short_rate
 export Projection, CashflowProjection
 export pv

--- a/src/Projection.jl
+++ b/src/Projection.jl
@@ -170,6 +170,18 @@ end
     return p_alt |> Map(cf -> @set cf.time += fwd_start)
 end
 
+# an `FX.Converted` contract's cashflows are denominated in the base (foreign) currency
+# of an FX pair; convert each amount into the quote (domestic) currency at the
+# arbitrage-free forward exchange rate for its payment time. The FX model is looked up
+# from the projection's model store by key, mirroring `Bond.Floating`'s reference-rate
+# lookup, so the wrapped contract still sees the same store (a converted floating leg
+# resolves its own reference curve from it).
+@inline function Transducers.asfoldable(p::Projection{C, M, K}) where {C <: FX.Converted, M, K <: CashflowProjection}
+    fx = p.model[p.contract.key]
+    p_alt = @set p.contract = p.contract.contract
+    return p_alt |> Map(cf -> @set cf.amount *= forward(fx, cf.time))
+end
+
 @inline function Transducers.asfoldable(p::Projection{C, M, K}) where {C <: Cashflow, M, K <: CashflowProjection}
     return Ref(p.contract) |> Map(identity)
 end

--- a/src/Projection.jl
+++ b/src/Projection.jl
@@ -182,6 +182,17 @@ end
     return p_alt |> Map(cf -> @set cf.amount *= forward(fx, cf.time))
 end
 
+# an `FX.BasisSwapLeg` is a materialized strip of base-currency cashflows; emit them
+# directly (they need no model to resolve). A leaf contract needs `__foldl__`, not
+# `asfoldable`: wrapper rules like `FX.Converted`'s fold their inner projection through
+# an Eduction, which resolves `__foldl__` methods but does not re-apply `asfoldable`.
+@inline function Transducers.__foldl__(rf, val, p::Projection{C, M, K}) where {C <: FX.BasisSwapLeg, M, K}
+    for cf in p.contract.cashflows
+        val = @next(rf, val, cf)
+    end
+    return complete(rf, val)
+end
+
 @inline function Transducers.asfoldable(p::Projection{C, M, K}) where {C <: Cashflow, M, K <: CashflowProjection}
     return Ref(p.contract) |> Map(identity)
 end

--- a/src/Projection.jl
+++ b/src/Projection.jl
@@ -185,6 +185,11 @@ end
     if !(fx isa FX.AbstractFXModel)
         throw(ArgumentError("`FX.Converted` expects an FX model (e.g. `FX.Forwards`) under the key $(repr(p.contract.key)), but the projection's model store holds a $(typeof(fx))"))
     end
+    # the declared pair guards the conversion's direction: an inverted (or crossed)
+    # model under an otherwise-valid key would silently multiply by the reciprocal rate
+    if fx.pair != p.contract.pair
+        throw(ArgumentError("`FX.Converted` declared $(p.contract.pair) but the model under key $(repr(p.contract.key)) prices $(fx.pair)"))
+    end
     p_alt = @set p.contract = p.contract.contract
     return p_alt |> Map(cf -> @set cf.amount *= forward(fx, cf.time))
 end

--- a/src/Projection.jl
+++ b/src/Projection.jl
@@ -178,6 +178,13 @@ end
 # resolves its own reference curve from it).
 @inline function Transducers.asfoldable(p::Projection{C, M, K}) where {C <: FX.Converted, M, K <: CashflowProjection}
     fx = p.model[p.contract.key]
+    # a mis-keyed store (e.g. a yield curve where the FX model belongs) would otherwise
+    # fail deep inside the transducer pipeline — `forward(curve, t)` returns a `Rate`,
+    # which `Rate`-scales the amount and only errors at `Cashflow` reconstruction; name
+    # the actual problem at its source instead
+    if !(fx isa FX.AbstractFXModel)
+        throw(ArgumentError("`FX.Converted` expects an FX model (e.g. `FX.Forwards`) under the key $(repr(p.contract.key)), but the projection's model store holds a $(typeof(fx))"))
+    end
     p_alt = @set p.contract = p.contract.contract
     return p_alt |> Map(cf -> @set cf.amount *= forward(fx, cf.time))
 end

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -391,14 +391,16 @@ end
 fit(::Spline.MonotoneConvex, quotes, ::Fit.Bootstrap) = fit(Yield.MonotoneConvex(), quotes)
 
 # FX.Forwards with a spline placeholder as the foreign curve: given spot, the domestic
-# curve, and forward quotes, the implied base-currency discount factors are closed-form
-# (DF_f(t) = (K·DF_d(t) + price)/spot — see `FX.implied_zcb_quotes`), so curve
-# construction reduces to fitting the spline through the implied zero-coupon quotes; no
-# optimizer runs over the FX model itself. The two dispatch methods are deliberately
-# separate (not a `Union`) so neither is ambiguous against the generic optic-based
-# `fit(mod0, quotes, ::Fit.Loss)`.
+# curve, and market quotes, each quote reduces to an equivalent quote on the
+# base-currency discount curve — closed-form implied zero-coupon quotes for outright
+# forwards (DF_f(t) = (K·DF_d(t) + price)/spot, see `FX.implied_zcb_quotes`) and par
+# cashflow strips for basis swaps (see `FX.ParBasisSwap`) — so curve construction
+# reduces to fitting the spline through those quotes; no optimizer runs over the FX
+# model itself, and one quote set may mix both instrument types. The two dispatch
+# methods are deliberately separate (not a `Union`) so neither is ambiguous against the
+# generic optic-based `fit(mod0, quotes, ::Fit.Loss)`.
 function __fit_fx_via_implied(mod0, quotes, method)
-    implied = FX.implied_zcb_quotes(mod0, quotes)
+    implied = map(q -> FX.__implied_foreign_quote(mod0, q), quotes)
     return @set mod0.foreign = fit(mod0.foreign, implied, method)
 end
 fit(mod0::FX.Forwards{P, S, D, F}, quotes, method::Fit.Bootstrap) where {P, S, D, F <: Spline.SplineCurve} = __fit_fx_via_implied(mod0, quotes, method)

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -394,17 +394,15 @@ fit(::Spline.MonotoneConvex, quotes, ::Fit.Bootstrap) = fit(Yield.MonotoneConvex
 # curve, and forward quotes, the implied base-currency discount factors are closed-form
 # (DF_f(t) = (K·DF_d(t) + price)/spot — see `FX.implied_zcb_quotes`), so curve
 # construction reduces to fitting the spline through the implied zero-coupon quotes; no
-# optimizer runs over the FX model itself. The two methods are deliberately separate
-# (not a `Union`) so neither is ambiguous against the generic optic-based
+# optimizer runs over the FX model itself. The two dispatch methods are deliberately
+# separate (not a `Union`) so neither is ambiguous against the generic optic-based
 # `fit(mod0, quotes, ::Fit.Loss)`.
-function fit(mod0::FX.Forwards{P, S, D, F}, quotes, method::Fit.Bootstrap) where {P, S, D, F <: Spline.SplineCurve}
+function __fit_fx_via_implied(mod0, quotes, method)
     implied = FX.implied_zcb_quotes(mod0, quotes)
     return @set mod0.foreign = fit(mod0.foreign, implied, method)
 end
-function fit(mod0::FX.Forwards{P, S, D, F}, quotes, method::Fit.Loss) where {P, S, D, F <: Spline.SplineCurve}
-    implied = FX.implied_zcb_quotes(mod0, quotes)
-    return @set mod0.foreign = fit(mod0.foreign, implied, method)
-end
+fit(mod0::FX.Forwards{P, S, D, F}, quotes, method::Fit.Bootstrap) where {P, S, D, F <: Spline.SplineCurve} = __fit_fx_via_implied(mod0, quotes, method)
+fit(mod0::FX.Forwards{P, S, D, F}, quotes, method::Fit.Loss) where {P, S, D, F <: Spline.SplineCurve} = __fit_fx_via_implied(mod0, quotes, method)
 
 function fit(mod0::T, quotes, method::Fit.Bootstrap) where {T <: Spline.SplineCurve}
     quotes = sort(collect(quotes); by = maturity)

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -171,6 +171,13 @@ __default_optic(m::ShortRate.HullWhite) = (
     @optic(_.a) => 0.0 .. 5.0,
     @optic(_.σ) => 0.0 .. 1.0,
 )
+# FX.Forwards: the free variables live on the base-currency (`foreign`) curve — spot and
+# the domestic curve are calibration inputs — so compose the foreign curve's own optics
+# through the `foreign` field.
+__default_optic(m::FX.Forwards) = map(o -> __fx_foreign_optic(o), __default_optic(m.foreign))
+__fx_foreign_optic(o::Base.Pair) = Accessors.opcompose(@optic(_.foreign), o.first) => o.second
+__fx_foreign_optic(o::Tuple) = (Accessors.opcompose(@optic(_.foreign), only(o)),)
+__fx_foreign_optic(o) = Accessors.opcompose(@optic(_.foreign), o)
 
 
 __default_optim(m) = OptimizationOptimJL.LBFGS()
@@ -382,6 +389,22 @@ function fit(::Spline.MonotoneConvex, quotes, method::Fit.Loss; optimizer = Opti
     return fit(Yield.MonotoneConvex(), quotes, method; optimizer)
 end
 fit(::Spline.MonotoneConvex, quotes, ::Fit.Bootstrap) = fit(Yield.MonotoneConvex(), quotes)
+
+# FX.Forwards with a spline placeholder as the foreign curve: given spot, the domestic
+# curve, and forward quotes, the implied base-currency discount factors are closed-form
+# (DF_f(t) = (K·DF_d(t) + price)/spot — see `FX.implied_zcb_quotes`), so curve
+# construction reduces to fitting the spline through the implied zero-coupon quotes; no
+# optimizer runs over the FX model itself. The two methods are deliberately separate
+# (not a `Union`) so neither is ambiguous against the generic optic-based
+# `fit(mod0, quotes, ::Fit.Loss)`.
+function fit(mod0::FX.Forwards{P, S, D, F}, quotes, method::Fit.Bootstrap) where {P, S, D, F <: Spline.SplineCurve}
+    implied = FX.implied_zcb_quotes(mod0, quotes)
+    return @set mod0.foreign = fit(mod0.foreign, implied, method)
+end
+function fit(mod0::FX.Forwards{P, S, D, F}, quotes, method::Fit.Loss) where {P, S, D, F <: Spline.SplineCurve}
+    implied = FX.implied_zcb_quotes(mod0, quotes)
+    return @set mod0.foreign = fit(mod0.foreign, implied, method)
+end
 
 function fit(mod0::T, quotes, method::Fit.Bootstrap) where {T <: Spline.SplineCurve}
     quotes = sort(collect(quotes); by = maturity)

--- a/src/model/FX.jl
+++ b/src/model/FX.jl
@@ -113,7 +113,8 @@ also callable: `m(t) == forward(m, t)`.
 
 # Arguments
 - `pair`: the [`FX.Pair`](@ref) this model prices, e.g. `FX.Pair(:EUR, :USD)`.
-- `spot`: the current exchange rate (quote currency per unit of base currency).
+- `spot`: the current exchange rate (quote currency per unit of base currency); must
+  be strictly positive and finite, or construction throws an `ArgumentError`.
 - `domestic`: the *quote*-currency discount curve (any yield model).
 - `foreign`: the *base*-currency discount curve (any yield model). See the note on
   cross-currency basis below.
@@ -165,6 +166,15 @@ struct Forwards{P <: Pair, S, D, F} <: AbstractFXModel
     spot::S
     domestic::D
     foreign::F
+    function Forwards(pair::P, spot::S, domestic::D, foreign::F) where {P <: Pair, S, D, F}
+        # an exchange rate is a strictly positive price: zero, negative, or non-finite
+        # spot would silently corrupt every downstream forward, pv, inversion, and
+        # implied discount factor rather than erroring anywhere near the cause
+        if !(isfinite(spot) && spot > 0)
+            throw(ArgumentError("spot must be a strictly positive, finite exchange rate; got $spot"))
+        end
+        return new{P, S, D, F}(pair, spot, domestic, foreign)
+    end
 end
 
 FinanceCore.forward(m::Forwards, to) = m.spot * discount(m.foreign, to) / discount(m.domestic, to)
@@ -261,8 +271,8 @@ Outright(pair::Pair, forward_rate, time) = Quote(zero(forward_rate), Forward(pai
 function __implied_zcb_quote(q::Quote{<:Any, <:Forward}, spot, domestic)
     c = q.instrument
     df = (c.strike * discount(domestic, c.time) + q.price) / spot
-    if !(df > 0)
-        throw(ArgumentError("the FX forward quote at time $(c.time) implies a non-positive base-currency discount factor ($df); check the quote's price, points scale, and spot"))
+    if !(isfinite(df) && df > 0)
+        throw(ArgumentError("the FX forward quote at time $(c.time) implies a non-positive or non-finite base-currency discount factor ($df); check the quote's price, points scale, and spot"))
     end
     return Quote(df, Cashflow(one(df), c.time))
 end
@@ -321,14 +331,21 @@ function implied_zcb_quotes(m::Forwards, quotes)
 end
 
 """
-    FX.Converted(contract, key)
+    FX.Converted(contract, pair, key)
 
-Wrap a contract whose cashflows are denominated in the *base* (foreign) currency of an
-FX pair, converting each projected cashflow into the *quote* (domestic) currency at the
+Wrap a contract whose cashflows are denominated in the *base* (foreign) currency of
+`pair`, converting each projected cashflow into the *quote* (domestic) currency at the
 arbitrage-free forward exchange rate for that cashflow's time: an amount paid at time
 `t` is multiplied by `forward(fx, t)`, where `fx` is the [`FX.Forwards`](@ref) model
 looked up from the projection's model store under `key` — the same key/value pattern
 used by [`Bond.Floating`](@ref FinanceModels.Bond.Floating) for its reference rate.
+
+`pair` declares the conversion the wrapper expects: if the model found under `key` is
+for a different pair — including the *inverted* one — projection throws an
+`ArgumentError` naming both pairs, rather than silently converting at a crossed or
+reciprocal rate. What the wrapper *cannot* verify is the wrapped contract's own
+denomination, since bare cashflows carry no currency; `pair` is your declaration that
+its cashflows are base-currency amounts.
 
 Converting at CIP forwards and then discounting on the domestic curve is identical to
 discounting the unconverted cashflows on the FX model's foreign curve and converting the
@@ -359,17 +376,18 @@ eur = Yield.Constant(Continuous(0.03))
 fx = FX.Forwards(eurusd, 1.08, usd, eur)
 
 bond = Bond.Fixed(0.04, Periodic(1), 2.0)  # a EUR-denominated bond
-p = Projection(FX.Converted(bond, "EURUSD"), Dict("EURUSD" => fx), CashflowProjection())
+p = Projection(FX.Converted(bond, eurusd, "EURUSD"), Dict("EURUSD" => fx), CashflowProjection())
 
 collect(p)  # cashflows now in USD: each amount is multiplied by forward(fx, t)
 pv(usd, p)  # == 1.08 * pv(eur, bond)
 ```
 """
-struct Converted{C, K} <: FinanceCore.AbstractContract
+struct Converted{C, P <: Pair, K} <: FinanceCore.AbstractContract
     # `contract` is deliberately unconstrained (like `FinanceCore.Composite`) so that
     # transducer-wrapped contracts (`Transducers.Eduction`s such as `bond |> Map(-)`)
     # can be converted too.
     contract::C
+    pair::P
     key::K
 end
 
@@ -426,10 +444,11 @@ is therefore `Quote(1.0, FX.BasisSwapLeg(pair, cashflows))`: a deterministic
 base-currency cashflow strip that must price to par on the curve being fit. Each coupon
 is fix-in-advance at the `reference` forward over its accrual period, exactly matching
 how [`Bond.Floating`](@ref FinanceModels.Bond.Floating) projects, so the strip equals
-the projected floating leg. A `maturity` that is not a whole number of periods
-produces a front stub which — again exactly like `Bond.Floating` — still accrues
-`1/frequency` and reads its reference forward from `t - 1/frequency`, extrapolating
-the `reference` curve below time zero; prefer whole-period tenors.
+the projected floating leg. `maturity` must be a whole number of coupon periods;
+anything else throws an `ArgumentError`. A front stub would require a stub-accrual
+convention this constructor deliberately refuses to guess at — the naive `1/frequency`
+accrual `Bond.Floating` applies to stubs would silently mis-state the first coupon of
+a market quote.
 
 Because the strip is deterministic, these quotes flow through the same `fit` methods as
 [`FX.Outright`](@ref) quotes, and the two can be mixed in a single calibration —
@@ -454,6 +473,13 @@ see the "Foreign Exchange" documentation page.
 """
 function ParBasisSwap(pair::Pair, spread, maturity; reference, frequency = Periodic(4))
     f = frequency.frequency
+    n = maturity * f
+    # a market-quote constructor must not fabricate a stub coupon: the naive 1/f
+    # accrual (Bond.Floating's stub convention) would silently mis-state the first
+    # cashflow, so non-whole tenors are refused rather than guessed at
+    if !isapprox(n, round(n); atol = 1e-8)
+        throw(ArgumentError("maturity $maturity is not a whole number of coupon periods at frequency $f; basis-swap quotes are whole-tenor instruments"))
+    end
     ts = Bond.coupon_times(maturity, f)
     cfs = map(ts) do t
         # fix-in-advance forward + spread, replicating `Bond.Floating`'s projection

--- a/src/model/FX.jl
+++ b/src/model/FX.jl
@@ -4,6 +4,7 @@ The `FX` module provides foreign exchange models, contracts, and quote conventio
 - [`FX.Pair`](@ref) — a currency pair as a type-level object, e.g. `FX.Pair(:EUR, :USD)`
 - [`FX.Forwards`](@ref) — a covered-interest-parity model of outright FX forward rates, built from a spot rate and two discount curves
 - [`FX.Forward`](@ref) — an outright FX forward contract
+- [`FX.Converted`](@ref) — a wrapper that converts a contract's projected cashflows into the quote currency at CIP forward rates, enabling cross-currency swaps and hedged multi-currency valuation
 - [`FX.Outright`](@ref) and [`FX.ForwardPoints`](@ref) — market quote conventions, returning `Quote`s
 - [`FX.implied_zcb_quotes`](@ref) — transform FX forward quotes into the implied base-currency zero-coupon quotes used for curve construction
 
@@ -280,5 +281,56 @@ function implied_zcb_quotes(m::Forwards, quotes)
     end
     return implied_zcb_quotes(quotes, m.spot, m.domestic)
 end
+
+"""
+    FX.Converted(contract, key)
+
+Wrap a contract whose cashflows are denominated in the *base* (foreign) currency of an
+FX pair, converting each projected cashflow into the *quote* (domestic) currency at the
+arbitrage-free forward exchange rate for that cashflow's time: an amount paid at time
+`t` is multiplied by `forward(fx, t)`, where `fx` is the [`FX.Forwards`](@ref) model
+looked up from the projection's model store under `key` — the same key/value pattern
+used by [`Bond.Floating`](@ref FinanceModels.Bond.Floating) for its reference rate.
+
+Converting at CIP forwards and then discounting on the domestic curve is identical to
+discounting the unconverted cashflows on the FX model's foreign curve and converting the
+result at spot:
+
+    pv(domestic, Converted(c)) == spot * pv(foreign, c)
+
+so collateralized (hedged) cross-currency valuation is consistent whichever way it is
+sliced, and — when the FX model was fit to market forwards — automatically reflects the
+cross-currency basis.
+
+Because the wrapper works on *any* projectable contract (including transducer-modified
+ones and [`Bond.Floating`](@ref FinanceModels.Bond.Floating), whose reference model is
+resolved from the same store), cross-currency swaps are ordinary [`Composite`](@ref
+FinanceCore.Composite)s — see the "Foreign Exchange" documentation page for a worked
+fixed-for-fixed and floating-floating example.
+
+# Examples
+
+```julia
+eurusd = FX.Pair(:EUR, :USD)
+usd = Yield.Constant(Continuous(0.05))
+eur = Yield.Constant(Continuous(0.03))
+fx = FX.Forwards(eurusd, 1.08, usd, eur)
+
+bond = Bond.Fixed(0.04, Periodic(1), 2.0)  # a EUR-denominated bond
+p = Projection(FX.Converted(bond, "EURUSD"), Dict("EURUSD" => fx), CashflowProjection())
+
+collect(p)  # cashflows now in USD: each amount is multiplied by forward(fx, t)
+pv(usd, p)  # == 1.08 * pv(eur, bond)
+```
+"""
+struct Converted{C, K} <: FinanceCore.AbstractContract
+    # `contract` is deliberately unconstrained (like `FinanceCore.Composite`) so that
+    # transducer-wrapped contracts (`Transducers.Eduction`s such as `bond |> Map(-)`)
+    # can be converted too.
+    contract::C
+    key::K
+end
+
+FinanceCore.maturity(c::Converted) = FinanceCore.maturity(c.contract)
 
 end

--- a/src/model/FX.jl
+++ b/src/model/FX.jl
@@ -42,7 +42,7 @@ using ..FinanceCore
 abstract type AbstractFXModel <: AbstractModel end
 
 """
-    FX.Pair(base::Symbol, quote::Symbol)
+    FX.Pair(base, quote)
 
 A currency pair as a singleton type. `FX.Pair(:EUR, :USD)` denotes the price of one unit
 of the *base* currency (`:EUR`) expressed in units of the *quote* — also called domestic
@@ -54,6 +54,15 @@ surface as immediate, descriptive errors rather than silently inverted prices: a
 the *same* pair.
 
 `inv` flips the pair: `inv(FX.Pair(:EUR, :USD)) == FX.Pair(:USD, :EUR)`.
+
+Currencies are usually `Symbol`s, but any value Julia admits as a type parameter works:
+`Symbol`s, types, or `isbits` values — e.g. `InlineStrings` currency codes
+(`FX.Pair(String3("EUR"), String3("USD"))`) or ISO 4217 numeric codes
+(`FX.Pair(978, 840)`). A plain `String` is not `isbits` and cannot be a type parameter;
+use a `Symbol` or an inline string instead. Distinct parameter values are distinct
+pairs: a `Symbol` pair and an inline-string pair of the same letters — or `String3` vs
+`String7` codes — do not match each other, and the usual pair-mismatch `ArgumentError`
+applies. Pick one convention for a given system.
 
 # Examples
 
@@ -67,11 +76,15 @@ FX.Pair(:USD, :EUR)
 """
 struct Pair{B, Q} end
 
-Pair(base::Symbol, quote_currency::Symbol) = Pair{base, quote_currency}()
+# any value Julia admits as a type parameter (Symbols, isbits values, types) works;
+# a plain `String` is not isbits and errors here naturally
+Pair(base, quote_currency) = Pair{base, quote_currency}()
 
 Base.inv(::Pair{B, Q}) where {B, Q} = Pair{Q, B}()
 Base.Broadcast.broadcastable(p::Pair) = Ref(p)
-Base.show(io::IO, ::Pair{B, Q}) where {B, Q} = print(io, "FX.Pair(:", B, ", :", Q, ")")
+# repr keeps Symbol pairs printing as `FX.Pair(:EUR, :USD)` while staying faithful for
+# non-Symbol parameters (e.g. inline strings, integer ISO codes)
+Base.show(io::IO, ::Pair{B, Q}) where {B, Q} = print(io, "FX.Pair(", repr(B), ", ", repr(Q), ")")
 
 """
     FX.Forwards(pair, spot, domestic, foreign)

--- a/src/model/FX.jl
+++ b/src/model/FX.jl
@@ -1,0 +1,284 @@
+"""
+The `FX` module provides foreign exchange models, contracts, and quote conventions:
+
+- [`FX.Pair`](@ref) — a currency pair as a type-level object, e.g. `FX.Pair(:EUR, :USD)`
+- [`FX.Forwards`](@ref) — a covered-interest-parity model of outright FX forward rates, built from a spot rate and two discount curves
+- [`FX.Forward`](@ref) — an outright FX forward contract
+- [`FX.Outright`](@ref) and [`FX.ForwardPoints`](@ref) — market quote conventions, returning `Quote`s
+- [`FX.implied_zcb_quotes`](@ref) — transform FX forward quotes into the implied base-currency zero-coupon quotes used for curve construction
+
+The design philosophy mirrors the rest of FinanceModels: market conventions that are a
+common source of silent errors (pair direction, points scale, which curve discounts what)
+are encoded explicitly in types and keyword arguments, and the curves inside an FX model
+are ordinary yield models, so splines, parametric curves, curve arithmetic
+(e.g. `foreign_ois + basis`), and `fit` all apply unchanged.
+
+# Example
+
+```julia
+using FinanceModels
+
+eurusd = FX.Pair(:EUR, :USD)
+usd = Yield.Constant(Continuous(0.05))
+
+# market outright forwards (or use FX.ForwardPoints for points quotes)
+quotes = FX.Outright.(eurusd, [1.1055, 1.1113, 1.1225, 1.1459], [0.25, 0.5, 1.0, 2.0])
+
+# closed-form implied EUR discount factors, bootstrapped through a spline
+m = fit(FX.Forwards(eurusd, 1.10, usd, Spline.Cubic()), quotes, Fit.Bootstrap())
+
+forward(m, 1.0)  # ≈ 1.1225, and every quote reprices to zero PV
+```
+"""
+module FX
+
+import ..AbstractModel
+import ..FinanceCore: Timepoint
+using ..FinanceCore
+
+abstract type AbstractFXModel <: AbstractModel end
+
+"""
+    FX.Pair(base::Symbol, quote::Symbol)
+
+A currency pair as a singleton type. `FX.Pair(:EUR, :USD)` denotes the price of one unit
+of the *base* currency (`:EUR`) expressed in units of the *quote* — also called domestic
+or terms — currency (`:USD`), matching the market's "EURUSD" naming.
+
+Carrying the pair at the type level means that direction errors — the classic FX bug —
+surface as immediate, descriptive errors rather than silently inverted prices: an
+[`FX.Forwards`](@ref) model only prices [`FX.Forward`](@ref) contracts denominated in
+the *same* pair.
+
+`inv` flips the pair: `inv(FX.Pair(:EUR, :USD)) == FX.Pair(:USD, :EUR)`.
+
+# Examples
+
+```julia-repl
+julia> FX.Pair(:EUR, :USD)
+FinanceModels.FX.Pair{:EUR, :USD}()
+
+julia> inv(FX.Pair(:EUR, :USD))
+FinanceModels.FX.Pair{:USD, :EUR}()
+```
+"""
+struct Pair{B, Q} end
+
+Pair(base::Symbol, quote_currency::Symbol) = Pair{base, quote_currency}()
+
+Base.inv(::Pair{B, Q}) where {B, Q} = Pair{Q, B}()
+Base.Broadcast.broadcastable(p::Pair) = Ref(p)
+
+"""
+    FX.Forwards(pair, spot, domestic, foreign)
+
+A covered-interest-parity (CIP) model of outright FX forward rates for the given
+[`FX.Pair`](@ref):
+
+    forward(m, t) = spot * discount(foreign, t) / discount(domestic, t)
+
+where `forward(m, t)` is the arbitrage-free forward exchange rate (quote currency per one
+unit of base currency) for delivery at time `t`, and `forward(m, 0) == spot`. The model is
+also callable: `m(t) == forward(m, t)`.
+
+# Arguments
+- `pair`: the [`FX.Pair`](@ref) this model prices, e.g. `FX.Pair(:EUR, :USD)`.
+- `spot`: the current exchange rate (quote currency per unit of base currency).
+- `domestic`: the *quote*-currency discount curve (any yield model).
+- `foreign`: the *base*-currency discount curve (any yield model). See the note on
+  cross-currency basis below.
+
+`inv(m)` returns the model for the flipped pair: spot is inverted and the curves swap
+roles, so `forward(inv(m), t) == 1 / forward(m, t)`.
+
+# Cross-currency basis
+
+`foreign` is defined by what reprices the FX market, *not* necessarily the base currency's
+own OIS or government curve. Since the collapse of covered interest parity against
+textbook curves (post-2008), market forwards embed a cross-currency basis. Two equivalent
+ways to handle it:
+
+- **Absorbed**: `fit` the model to market forward quotes (see [`FX.implied_zcb_quotes`](@ref)
+  and the `fit` methods for `FX.Forwards`). The fitted `foreign` curve *is* the
+  basis-adjusted ("CSA" / collateralized) discount curve, and the basis is embedded —
+  hedge pricing with the fitted model is basis-consistent by construction.
+- **Explicit**: build `foreign` compositionally from a base-currency OIS curve and a
+  fitted basis spread curve using ordinary curve arithmetic: `foreign_ois + basis`
+  (zero-rate addition via `CompositeYield`). The basis curve is then a first-class,
+  inspectable object: `basis = implied_foreign - foreign_ois`.
+
+# Examples
+
+```julia
+eurusd = FX.Pair(:EUR, :USD)
+usd = Yield.Constant(Continuous(0.05))
+eur = Yield.Constant(Continuous(0.03))
+
+m = FX.Forwards(eurusd, 1.10, usd, eur)
+
+forward(m, 0.0)  # 1.10 (spot)
+forward(m, 1.0)  # 1.10 * exp(0.05 - 0.03) ≈ 1.12222
+m(1.0)           # same as forward(m, 1.0)
+
+# explicit −20bp EUR/USD cross-currency basis on the EUR leg:
+m_basis = FX.Forwards(eurusd, 1.10, usd, eur + Yield.Constant(Continuous(-0.002)))
+```
+"""
+struct Forwards{P <: Pair, S, D, F} <: AbstractFXModel
+    pair::P
+    spot::S
+    domestic::D
+    foreign::F
+end
+
+FinanceCore.forward(m::Forwards, to) = m.spot * discount(m.foreign, to) / discount(m.domestic, to)
+(m::Forwards)(t) = FinanceCore.forward(m, t)
+
+Base.inv(m::Forwards) = Forwards(inv(m.pair), inv(m.spot), m.foreign, m.domestic)
+
+"""
+    FX.Forward(pair, strike, time)
+
+An outright FX forward contract: at `time`, receive one unit of the base currency of
+`pair` and pay `strike` units of the quote currency. Its value is expressed in the quote
+currency.
+
+Under an [`FX.Forwards`](@ref) model `m` for the same pair:
+
+    present_value(m, c) = (forward(m, c.time) - c.strike) * discount(m.domestic, c.time)
+
+A forward struck at the market outright has zero present value, which is how market
+quotes are represented — see [`FX.Outright`](@ref).
+
+Pricing a contract whose pair differs from the model's pair throws an `ArgumentError`
+naming both pairs, rather than producing a silently inverted or crossed price.
+
+# Examples
+
+```julia
+eurusd = FX.Pair(:EUR, :USD)
+m = FX.Forwards(eurusd, 1.10, Yield.Constant(Continuous(0.05)), Yield.Constant(Continuous(0.03)))
+
+atm = FX.Forward(eurusd, forward(m, 1.0), 1.0)
+present_value(m, atm)  # 0.0
+
+off = FX.Forward(eurusd, 1.10, 1.0)  # struck below the forward
+present_value(m, off)  # (forward(m, 1.0) - 1.10) * discount at 1.0 > 0
+```
+"""
+struct Forward{P <: Pair, K, T <: Timepoint} <: FinanceCore.AbstractContract
+    pair::P
+    strike::K
+    time::T
+end
+
+FinanceCore.maturity(c::Forward) = c.time
+
+function FinanceCore.present_value(m::Forwards{P}, c::Forward{P}) where {P <: Pair}
+    return (FinanceCore.forward(m, c.time) - c.strike) * discount(m.domestic, c.time)
+end
+
+# a mismatched pair would otherwise fall through to the generic projection-based
+# `present_value` and fail with an unrelated-looking iteration error; name the actual
+# problem instead. The diagonal `{P,P}` method above is more specific, so matched pairs
+# never reach this.
+function FinanceCore.present_value(m::Forwards, c::Forward)
+    throw(ArgumentError("cannot price an FX.Forward on $(c.pair) with an FX.Forwards model for $(m.pair)"))
+end
+
+"""
+    FX.Outright(pair, forward_rate, time)
+
+A `Quote` for an outright FX forward: entering a forward at the market rate costs
+nothing, so this returns a zero-price `Quote` on an [`FX.Forward`](@ref) struck at
+`forward_rate`. This is the analog of par-bond quoting for FX and is the input to the
+`fit` methods for [`FX.Forwards`](@ref).
+
+Use broadcasting to create a set of quotes: `FX.Outright.(pair, rates, times)`.
+
+See also [`FX.ForwardPoints`](@ref) for the points-over-spot convention.
+
+# Examples
+
+```julia-repl
+julia> FX.Outright(FX.Pair(:EUR, :USD), 1.1225, 1.0)
+Quote{Float64, FinanceModels.FX.Forward{FinanceModels.FX.Pair{:EUR, :USD}, Float64, Float64}}(0.0, FinanceModels.FX.Forward{FinanceModels.FX.Pair{:EUR, :USD}, Float64, Float64}(FinanceModels.FX.Pair{:EUR, :USD}(), 1.1225, 1.0))
+```
+"""
+Outright(pair::Pair, forward_rate, time) = Quote(zero(forward_rate), Forward(pair, forward_rate, time))
+
+"""
+    FX.ForwardPoints(pair, points, time; spot, scale=10_000)
+
+A `Quote` for an FX forward quoted as *forward points* over spot, the interbank
+convention: the outright forward rate is `spot + points / scale`.
+
+`scale` is the pip factor and is deliberately explicit: it is `10_000` for most pairs
+(one pip = 0.0001), but `100` for JPY-quoted pairs (one pip = 0.01). Returns the same
+zero-price `Quote` as [`FX.Outright`](@ref).
+
+# Examples
+
+```julia
+eurusd = FX.Pair(:EUR, :USD)
+FX.ForwardPoints(eurusd, 25.0, 0.5; spot = 1.10)                      # outright 1.1025
+FX.ForwardPoints(FX.Pair(:USD, :JPY), -30.0, 1.0; spot = 150.0, scale = 100)  # outright 149.70
+```
+"""
+ForwardPoints(pair::Pair, points, time; spot, scale = 10_000) = Outright(pair, spot + points / scale, time)
+
+"""
+    FX.implied_zcb_quotes(quotes, spot, domestic)
+    FX.implied_zcb_quotes(m::FX.Forwards, quotes)
+
+Transform FX forward `quotes` (as produced by [`FX.Outright`](@ref) /
+[`FX.ForwardPoints`](@ref)) into zero-coupon-bond `Quote`s for the *implied
+base-currency discount curve*, given the `spot` rate and the `domestic`
+(quote-currency) discount curve.
+
+Because a forward's price is `(F(t) - K) * DF_d(t)`, the implied base-currency discount
+factor at each quote's maturity is closed-form:
+
+    DF_f(t) = (K * DF_d(t) + price) / spot
+
+(for the usual zero-price outright quotes this is `F(t) * DF_d(t) / spot`). The returned
+quotes can be fed to any curve-fitting method — this is how the `fit` methods for
+[`FX.Forwards`](@ref) construct the foreign curve, and the resulting curve is the
+basis-adjusted (CSA) discount curve described in [`FX.Forwards`](@ref).
+
+All quotes must share a single currency pair (and match the model's pair in the second
+form); mixed pairs throw an `ArgumentError`, since they would otherwise blend into a
+meaningless curve.
+
+# Examples
+
+```julia
+eurusd = FX.Pair(:EUR, :USD)
+usd = Yield.Constant(Continuous(0.05))
+quotes = FX.Outright.(eurusd, [1.1055, 1.1113, 1.1225], [0.25, 0.5, 1.0])
+
+implied = FX.implied_zcb_quotes(quotes, 1.10, usd)   # Vector of ZCB-price Quotes
+eur = fit(Spline.Cubic(), implied, Fit.Bootstrap())  # the implied EUR discount curve
+```
+"""
+function implied_zcb_quotes(quotes, spot, domestic)
+    pair = first(quotes).instrument.pair
+    return map(quotes) do q
+        c = q.instrument
+        if c.pair != pair
+            throw(ArgumentError("FX quotes must share a single currency pair; got both $(pair) and $(c.pair)"))
+        end
+        df = (c.strike * discount(domestic, c.time) + q.price) / spot
+        Quote(df, Cashflow(one(df), c.time))
+    end
+end
+
+function implied_zcb_quotes(m::Forwards, quotes)
+    qpair = first(quotes).instrument.pair
+    if qpair != m.pair
+        throw(ArgumentError("quotes are for $(qpair) but the model prices $(m.pair)"))
+    end
+    return implied_zcb_quotes(quotes, m.spot, m.domestic)
+end
+
+end

--- a/src/model/FX.jl
+++ b/src/model/FX.jl
@@ -436,19 +436,28 @@ Quoting assumption (standard for collateralized, OIS-discounted swaps): the dome
 leg pays the forwards of the *same* curve used for domestic discounting, so it is worth
 par and drops out of the calibration. What remains is the base-currency par condition
 
-    Σᵢ (fᵢ + spread) * δ * DF_f(tᵢ) + DF_f(T) = 1
+    Σᵢ (fᵢ + spread) * δᵢ * DF_f(tᵢ) + DF_f(T) = 1
 
-where `fᵢ` are the (known) `reference` projection forwards, `δ` the accrual fraction,
-and `DF_f` the basis-adjusted (CSA) discount curve being calibrated. The returned quote
-is therefore `Quote(1.0, FX.BasisSwapLeg(pair, cashflows))`: a deterministic
-base-currency cashflow strip that must price to par on the curve being fit. Each coupon
-is fix-in-advance at the `reference` forward over its accrual period, exactly matching
-how [`Bond.Floating`](@ref FinanceModels.Bond.Floating) projects, so the strip equals
-the projected floating leg. `maturity` must be a whole number of coupon periods;
-anything else throws an `ArgumentError`. A front stub would require a stub-accrual
-convention this constructor deliberately refuses to guess at — the naive `1/frequency`
-accrual `Bond.Floating` applies to stubs would silently mis-state the first coupon of
-a market quote.
+where `fᵢ` is the (known) simple annualized `reference` forward over each coupon's
+accrual window, `δᵢ` the window's length (`1/frequency` except for a short first
+stub), and `DF_f` the basis-adjusted (CSA) discount curve being calibrated. The
+returned quote is therefore `Quote(1.0, FX.BasisSwapLeg(pair, cashflows))`: a
+deterministic base-currency cashflow strip that must price to par on the curve being
+fit. Each coupon is fix-in-advance at the `reference` forward over its accrual period,
+exactly matching how [`Bond.Floating`](@ref FinanceModels.Bond.Floating) projects for
+whole-period tenors, so the strip equals the projected floating leg.
+
+A `maturity` that is not a whole number of periods keeps the schedule anchored at
+maturity (regular `1/frequency` periods counted backward — the shape
+`Bond.coupon_times` produces) and makes the *first* period a short stub. The stub
+coupon accrues its actual length at the forward over its true window `[0, t₁]` (never
+a negative time), compound-accrued so that a zero-spread leg on its own curve
+telescopes to exactly par — the same stub convention as
+[`ParYield`](@ref FinanceModels.Bond.ParYield)'s sub-period par bonds. This is deliberately
+more careful than `Bond.Floating`, which applies a full `1/frequency` accrual to stub
+periods, so the strip-equals-projected-leg identity above is exact for whole-period
+tenors only. Schedules irregular anywhere else (long stubs, back stubs, custom rolls)
+are out of scope.
 
 Because the strip is deterministic, these quotes flow through the same `fit` methods as
 [`FX.Outright`](@ref) quotes, and the two can be mixed in a single calibration —
@@ -473,19 +482,19 @@ see the "Foreign Exchange" documentation page.
 """
 function ParBasisSwap(pair::Pair, spread, maturity; reference, frequency = Periodic(4))
     f = frequency.frequency
-    n = maturity * f
-    # a market-quote constructor must not fabricate a stub coupon: the naive 1/f
-    # accrual (Bond.Floating's stub convention) would silently mis-state the first
-    # cashflow, so non-whole tenors are refused rather than guessed at
-    if !isapprox(n, round(n); atol = 1e-8)
-        throw(ArgumentError("maturity $maturity is not a whole number of coupon periods at frequency $f; basis-swap quotes are whole-tenor instruments"))
-    end
     ts = Bond.coupon_times(maturity, f)
-    cfs = map(ts) do t
-        # fix-in-advance forward + spread, replicating `Bond.Floating`'s projection
-        # (which the FX module cannot call directly: `Projection` loads after it)
-        reference_rate = rate(frequency(forward(reference, t - 1 / f, t)))
-        coup = (reference_rate + spread) / f
+    cfs = map(eachindex(ts)) do i
+        t = ts[i]
+        # each coupon fixes in advance over its *actual* accrual window: [0, t₁] for
+        # a short first stub, regular 1/f windows thereafter — never a negative-time
+        # lookback. `fwd` is the simple annualized forward over the window: for whole
+        # periods it equals `Bond.Floating`'s f-periodic forward rate identically,
+        # and for the stub it compound-accrues (`ParYield`'s stub convention), so a
+        # zero-spread leg on its own curve is exactly par under any such schedule
+        start = i == 1 ? zero(t) : ts[i - 1]
+        δ = t - start
+        fwd = (1 / discount(reference, start, t) - 1) / δ
+        coup = (fwd + spread) * δ
         amt = t == last(ts) ? 1.0 + coup : coup
         Cashflow(amt, t)
     end

--- a/src/model/FX.jl
+++ b/src/model/FX.jl
@@ -472,13 +472,26 @@ quotes = [
     FX.Outright.(eurusd, [1.1055, 1.1113], [0.25, 0.5]);
     FX.ParBasisSwap.(eurusd, [-0.0012, -0.0018], [2.0, 5.0]; reference = estr)
 ]
-m = fit(FX.Forwards(eurusd, 1.10, sofr, Spline.Cubic()), quotes, Fit.Bootstrap())
+m = fit(FX.Forwards(eurusd, 1.10, sofr, Spline.Linear()), quotes, Fit.Bootstrap())
 ```
 
+Prefer a *local* interpolation (such as `Spline.Linear`, as above) when the quote set
+includes coupon-bearing instruments: their cashflows fall between knots, and a global
+spline reshapes already-solved segments as later knots are added, silently drifting
+solved quotes off par.
+
 This is the constant-notional representation. Interbank basis swaps are quoted on the
-mark-to-market (resetting-notional) structure; under deterministic curves the two par
-spreads agree to first order. The MTM contract itself is deliberately not modeled yet —
-see the "Foreign Exchange" documentation page.
+mark-to-market (resetting-notional) structure, in which the *flat domestic* leg's
+notional resets to spot each period while the spread leg's notional stays constant.
+Under the same quoting assumption as above and deterministic curves, the two par
+spreads are *exactly* equal: valued at CIP forwards, the resetting leg is a telescoping
+strip of one-period loans at its own curve's forwards — each worth par — so it drops
+out period by period just as the constant-notional leg drops out in one step, leaving
+the identical par condition (asserted to machine precision in the test suite). Quoted
+MTM spreads therefore calibrate this representation without approximation. The residual
+real-world difference is the FX–rates convexity of the resetting notional — identically
+zero under deterministic curves — which is one reason the MTM *contract* is deliberately
+not modeled yet; see the "Foreign Exchange" documentation page.
 """
 function ParBasisSwap(pair::Pair, spread, maturity; reference, frequency = Periodic(4))
     f = frequency.frequency

--- a/src/model/FX.jl
+++ b/src/model/FX.jl
@@ -15,6 +15,12 @@ are encoded explicitly in types and keyword arguments, and the curves inside an 
 are ordinary yield models, so splines, parametric curves, curve arithmetic
 (e.g. `foreign_ois + basis`), and `fit` all apply unchanged.
 
+Present values follow one rule: `present_value` is denominated in the currency of the
+contract's own cashflows — the *quote* currency for an [`FX.Forward`](@ref) (it settles
+in quote-currency units), the *base* currency for an [`FX.BasisSwapLeg`](@ref) (a strip
+of base-currency cashflows). Convert before combining values across denominations: a
+base-currency present value times spot is the quote-currency present value.
+
 # Example
 
 ```julia

--- a/src/model/FX.jl
+++ b/src/model/FX.jl
@@ -1,7 +1,7 @@
 """
 The `FX` module provides foreign exchange models, contracts, and quote conventions:
 
-- [`FX.Pair`](@ref) — a currency pair as a type-level object, e.g. `FX.Pair(:EUR, :USD)`
+- [`FX.Pair`](@ref) — a currency pair, e.g. `FX.Pair(:EUR, :USD)`
 - [`FX.Forwards`](@ref) — a covered-interest-parity model of outright FX forward rates, built from a spot rate and two discount curves
 - [`FX.Forward`](@ref) — an outright FX forward contract
 - [`FX.Converted`](@ref) — a wrapper that converts a contract's projected cashflows into the quote currency at CIP forward rates, enabling cross-currency swaps and hedged multi-currency valuation
@@ -50,25 +50,30 @@ abstract type AbstractFXModel <: AbstractModel end
 """
     FX.Pair(base, quote)
 
-A currency pair as a singleton type. `FX.Pair(:EUR, :USD)` denotes the price of one unit
-of the *base* currency (`:EUR`) expressed in units of the *quote* — also called domestic
-or terms — currency (`:USD`), matching the market's "EURUSD" naming.
+A currency pair. `FX.Pair(:EUR, :USD)` denotes the price of one unit of the *base*
+currency (`:EUR`) expressed in units of the *quote* — also called domestic or terms —
+currency (`:USD`), matching the market's "EURUSD" naming.
 
-Carrying the pair at the type level means that direction errors — the classic FX bug —
-surface as immediate, descriptive errors rather than silently inverted prices: an
-[`FX.Forwards`](@ref) model only prices [`FX.Forward`](@ref) contracts denominated in
-the *same* pair.
+Every FX contract and model carries its pair, so direction errors — the classic FX
+bug — surface as immediate, descriptive `ArgumentError`s rather than silently inverted
+prices: an [`FX.Forwards`](@ref) model only prices contracts denominated in an equal
+pair.
 
 `inv` flips the pair: `inv(FX.Pair(:EUR, :USD)) == FX.Pair(:USD, :EUR)`.
 
-Currencies are usually `Symbol`s, but any value Julia admits as a type parameter works:
-`Symbol`s, types, or `isbits` values — e.g. `InlineStrings` currency codes
-(`FX.Pair(String3("EUR"), String3("USD"))`) or ISO 4217 numeric codes
-(`FX.Pair(978, 840)`). A plain `String` is not `isbits` and cannot be a type parameter;
-use a `Symbol` or an inline string instead. Distinct parameter values are distinct
-pairs: a `Symbol` pair and an inline-string pair of the same letters — or `String3` vs
-`String7` codes — do not match each other, and the usual pair-mismatch `ArgumentError`
-applies. Pick one convention for a given system.
+Currencies are usually `Symbol`s, but any values work — strings (including the
+[InlineStrings](https://github.com/JuliaStrings/InlineStrings.jl) codes CSV readers
+produce) or ISO 4217 numeric codes (`FX.Pair(978, 840)`). Pairs compare by *content*:
+string-typed currencies are equal whenever their characters match, regardless of
+storage type — `FX.Pair(String3("EUR"), String3("USD")) == FX.Pair("EUR", "USD")` —
+because `AbstractString` equality and hashing are content-based. A `Symbol` pair and a
+string pair are *not* equal, however; pick one convention for a given system,
+normalizing at the data boundary (e.g. `Symbol.(codes)`) if sources disagree.
+
+A degenerate pair such as `FX.Pair(:USD, :USD)` is deliberately permitted: with unit
+spot and identical curves it is the *identity* pair (`forward ≡ 1`), which lets generic
+multi-currency code route domestic contracts through the same [`FX.Converted`](@ref)
+machinery as foreign ones.
 
 # Examples
 
@@ -80,17 +85,19 @@ julia> inv(FX.Pair(:EUR, :USD))
 FX.Pair(:USD, :EUR)
 ```
 """
-struct Pair{B, Q} end
+struct Pair{B, Q}
+    base::B
+    quote_currency::Q # `quote` is a reserved word in Julia
+end
 
-# any value Julia admits as a type parameter (Symbols, isbits values, types) works;
-# a plain `String` is not isbits and errors here naturally
-Pair(base, quote_currency) = Pair{base, quote_currency}()
-
-Base.inv(::Pair{B, Q}) where {B, Q} = Pair{Q, B}()
+Base.inv(p::Pair) = Pair(p.quote_currency, p.base)
+# content-based equality with a matching hash: pairs match whenever their currencies
+# compare equal, even across storage types — e.g. `String3("EUR")` vs `String7("EUR")`,
+# which CSV readers legitimately assign to different columns of the same codes
+Base.:(==)(a::Pair, b::Pair) = a.base == b.base && a.quote_currency == b.quote_currency
+Base.hash(p::Pair, h::UInt) = hash(p.quote_currency, hash(p.base, hash(:FXPair, h)))
 Base.Broadcast.broadcastable(p::Pair) = Ref(p)
-# repr keeps Symbol pairs printing as `FX.Pair(:EUR, :USD)` while staying faithful for
-# non-Symbol parameters (e.g. inline strings, integer ISO codes)
-Base.show(io::IO, ::Pair{B, Q}) where {B, Q} = print(io, "FX.Pair(", repr(B), ", ", repr(Q), ")")
+Base.show(io::IO, p::Pair) = print(io, "FX.Pair(", repr(p.base), ", ", repr(p.quote_currency), ")")
 
 """
     FX.Forwards(pair, spot, domestic, foreign)
@@ -112,7 +119,13 @@ also callable: `m(t) == forward(m, t)`.
   cross-currency basis below.
 
 `inv(m)` returns the model for the flipped pair: spot is inverted and the curves swap
-roles, so `forward(inv(m), t) == 1 / forward(m, t)`.
+roles, so `forward(inv(m), t) == 1 / forward(m, t)`. Inverting is calibration-exact —
+a model fit to market quotes reprices the inverted quotes at `1 / F` identically, with
+no refit.
+
+There is deliberately no two-time `forward(m, from, to)` (a `MethodError`): under CIP
+the fair forward for delivery at `to` is `forward(m, to)` no matter when the exchange
+is contracted, so the yield-curve forward-forward form has no FX analog.
 
 # Cross-currency basis
 
@@ -171,9 +184,11 @@ Under an [`FX.Forwards`](@ref) model `m` for the same pair:
     present_value(m, c, cur_time = 0.0) = (forward(m, c.time) - c.strike) * discount(m.domestic, cur_time, c.time)
 
 A forward struck at the market outright has zero present value, which is how market
-quotes are represented — see [`FX.Outright`](@ref). A forward that settled before
-`cur_time` is worth zero, consistent with how cashflows before `cur_time` are treated
-everywhere else in the package.
+quotes are represented — see [`FX.Outright`](@ref). `cur_time` moves only the
+discounting date — the model is *not* rolled: `forward(m, c.time)` is still today's
+forward, the package's usual static-curve valuation convention. A forward that settled
+before `cur_time` is worth zero, consistent with how cashflows before `cur_time` are
+treated everywhere else in the package.
 
 Pricing a contract whose pair differs from the model's pair throws an `ArgumentError`
 naming both pairs, rather than producing a silently inverted or crossed price.
@@ -199,19 +214,16 @@ end
 
 FinanceCore.maturity(c::Forward) = c.time
 
-function FinanceCore.present_value(m::Forwards{P}, c::Forward{P}, cur_time = 0.0) where {P <: Pair}
+function FinanceCore.present_value(m::Forwards, c::Forward, cur_time = 0.0)
+    # a mismatched pair would otherwise price a silently crossed/inverted rate — the
+    # classic FX bug this module exists to prevent
+    if c.pair != m.pair
+        throw(ArgumentError("cannot price an FX.Forward on $(c.pair) with an FX.Forwards model for $(m.pair)"))
+    end
     v = (FinanceCore.forward(m, c.time) - c.strike) * discount(m.domestic, cur_time, c.time)
     # a forward settled before the valuation time contributes nothing, matching the
     # projection-path convention (`Filter(cf -> cf.time >= cur_time)` in Projection.jl)
     return c.time < cur_time ? zero(v) : v
-end
-
-# a mismatched pair would otherwise fall through to the generic projection-based
-# `present_value` and fail with an unrelated-looking iteration error; name the actual
-# problem instead. The diagonal `{P,P}` method above is more specific, so matched pairs
-# never reach this.
-function FinanceCore.present_value(m::Forwards, c::Forward, cur_time = 0.0)
-    throw(ArgumentError("cannot price an FX.Forward on $(c.pair) with an FX.Forwards model for $(m.pair)"))
 end
 
 """
@@ -229,31 +241,47 @@ See also [`FX.ForwardPoints`](@ref) for the points-over-spot convention.
 # Examples
 
 ```julia-repl
-julia> FX.Outright(FX.Pair(:EUR, :USD), 1.1225, 1.0)
-Quote{Float64, FinanceModels.FX.Forward{FinanceModels.FX.Pair{:EUR, :USD}, Float64, Float64}}(0.0, FinanceModels.FX.Forward{FinanceModels.FX.Pair{:EUR, :USD}, Float64, Float64}(FX.Pair(:EUR, :USD), 1.1225, 1.0))
+julia> q = FX.Outright(FX.Pair(:EUR, :USD), 1.1225, 1.0);
+
+julia> q.price, q.instrument.strike, q.instrument.time
+(0.0, 1.1225, 1.0)
 ```
 """
 Outright(pair::Pair, forward_rate, time) = Quote(zero(forward_rate), Forward(pair, forward_rate, time))
 
 """
-    FX.ForwardPoints(pair, points, time; spot, scale=10_000)
+    FX.ForwardPoints(pair, points, time; spot, scale)
 
 A `Quote` for an FX forward quoted as *forward points* over spot, the interbank
 convention: the outright forward rate is `spot + points / scale`.
 
-`scale` is the pip factor and is deliberately explicit: it is `10_000` for most pairs
-(one pip = 0.0001), but `100` for JPY-quoted pairs (one pip = 0.01). Returns the same
-zero-price `Quote` as [`FX.Outright`](@ref).
+`scale` is the pip factor and is required rather than defaulted: it is `10_000` for
+most pairs (one pip = 0.0001) but `100` for JPY-quoted pairs (one pip = 0.01), and a
+silently assumed scale is exactly the off-by-100× points error this module refuses to
+guess about. Returns the same zero-price `Quote` as [`FX.Outright`](@ref).
 
 # Examples
 
 ```julia
 eurusd = FX.Pair(:EUR, :USD)
-FX.ForwardPoints(eurusd, 25.0, 0.5; spot = 1.10)                      # outright 1.1025
+FX.ForwardPoints(eurusd, 25.0, 0.5; spot = 1.10, scale = 10_000)               # outright 1.1025
 FX.ForwardPoints(FX.Pair(:USD, :JPY), -30.0, 1.0; spot = 150.0, scale = 100)  # outright 149.70
 ```
 """
-ForwardPoints(pair::Pair, points, time; spot, scale = 10_000) = Outright(pair, spot + points / scale, time)
+ForwardPoints(pair::Pair, points, time; spot, scale) = Outright(pair, spot + points / scale, time)
+
+# the closed-form implied base-currency discount factor for one forward quote:
+# DF_f(t) = (K·DF_d(t) + price)/spot. Guarded because a corrupt quote (wrong price
+# sign, points scale, or spot) implies df ≤ 0, which would otherwise surface only as
+# NaNs inside a downstream curve fit, far from the offending quote.
+function __implied_zcb_quote(q::Quote{<:Any, <:Forward}, spot, domestic)
+    c = q.instrument
+    df = (c.strike * discount(domestic, c.time) + q.price) / spot
+    if !(df > 0)
+        throw(ArgumentError("the FX forward quote at time $(c.time) implies a non-positive base-currency discount factor ($df); check the quote's price, points scale, and spot"))
+    end
+    return Quote(df, Cashflow(one(df), c.time))
+end
 
 """
     FX.implied_zcb_quotes(quotes, spot, domestic)
@@ -276,7 +304,9 @@ basis-adjusted (CSA) discount curve described in [`FX.Forwards`](@ref).
 
 All quotes must share a single currency pair (and match the model's pair in the second
 form); mixed pairs throw an `ArgumentError`, since they would otherwise blend into a
-meaningless curve.
+meaningless curve. A quote implying a non-positive discount factor (a corrupt price,
+points scale, or spot) also throws an `ArgumentError` naming the offending maturity,
+rather than letting NaNs surface inside a downstream curve fit.
 
 # Examples
 
@@ -292,12 +322,10 @@ eur = fit(Spline.Cubic(), implied, Fit.Bootstrap())  # the implied EUR discount 
 function implied_zcb_quotes(quotes, spot, domestic)
     pair = first(quotes).instrument.pair
     return map(quotes) do q
-        c = q.instrument
-        if c.pair != pair
-            throw(ArgumentError("FX quotes must share a single currency pair; got both $(pair) and $(c.pair)"))
+        if q.instrument.pair != pair
+            throw(ArgumentError("FX quotes must share a single currency pair; got both $(pair) and $(q.instrument.pair)"))
         end
-        df = (c.strike * discount(domestic, c.time) + q.price) / spot
-        Quote(df, Cashflow(one(df), c.time))
+        __implied_zcb_quote(q, spot, domestic)
     end
 end
 
@@ -387,12 +415,11 @@ end
 
 FinanceCore.maturity(c::BasisSwapLeg) = last(c.cashflows).time
 
-function FinanceCore.present_value(m::Forwards{P}, c::BasisSwapLeg{P}, cur_time = 0.0) where {P <: Pair}
-    return FinanceCore.present_value(m.foreign, c, cur_time)
-end
-
 function FinanceCore.present_value(m::Forwards, c::BasisSwapLeg, cur_time = 0.0)
-    throw(ArgumentError("cannot price an FX.BasisSwapLeg on $(c.pair) with an FX.Forwards model for $(m.pair)"))
+    if c.pair != m.pair
+        throw(ArgumentError("cannot price an FX.BasisSwapLeg on $(c.pair) with an FX.Forwards model for $(m.pair)"))
+    end
+    return FinanceCore.present_value(m.foreign, c, cur_time)
 end
 
 """
@@ -416,7 +443,10 @@ is therefore `Quote(1.0, FX.BasisSwapLeg(pair, cashflows))`: a deterministic
 base-currency cashflow strip that must price to par on the curve being fit. Each coupon
 is fix-in-advance at the `reference` forward over its accrual period, exactly matching
 how [`Bond.Floating`](@ref FinanceModels.Bond.Floating) projects, so the strip equals
-the projected floating leg.
+the projected floating leg. A `maturity` that is not a whole number of periods
+produces a front stub which — again exactly like `Bond.Floating` — still accrues
+`1/frequency` and reads its reference forward from `t - 1/frequency`, extrapolating
+the `reference` curve below time zero; prefer whole-period tenors.
 
 Because the strip is deterministic, these quotes flow through the same `fit` methods as
 [`FX.Outright`](@ref) quotes, and the two can be mixed in a single calibration —
@@ -459,13 +489,10 @@ end
 # calibration mix instrument types: outright forwards for the short end, par basis
 # swaps for the long end.
 function __implied_foreign_quote(m::Forwards, q::Quote{<:Any, <:Forward})
-    c = q.instrument
-    if c.pair != m.pair
-        throw(ArgumentError("quote is for $(c.pair) but the model prices $(m.pair)"))
+    if q.instrument.pair != m.pair
+        throw(ArgumentError("quote is for $(q.instrument.pair) but the model prices $(m.pair)"))
     end
-    # the closed-form implied discount factor — see `implied_zcb_quotes`
-    df = (c.strike * discount(m.domestic, c.time) + q.price) / m.spot
-    return Quote(df, Cashflow(one(df), c.time))
+    return __implied_zcb_quote(q, m.spot, m.domestic)
 end
 
 # a par basis-swap leg is already denominated on the base-currency curve; only check

--- a/src/model/FX.jl
+++ b/src/model/FX.jl
@@ -6,6 +6,7 @@ The `FX` module provides foreign exchange models, contracts, and quote conventio
 - [`FX.Forward`](@ref) — an outright FX forward contract
 - [`FX.Converted`](@ref) — a wrapper that converts a contract's projected cashflows into the quote currency at CIP forward rates, enabling cross-currency swaps and hedged multi-currency valuation
 - [`FX.Outright`](@ref) and [`FX.ForwardPoints`](@ref) — market quote conventions, returning `Quote`s
+- [`FX.ParBasisSwap`](@ref) — par cross-currency basis-swap spread quotes for calibrating the long-dated basis (with [`FX.BasisSwapLeg`](@ref) as the underlying instrument)
 - [`FX.implied_zcb_quotes`](@ref) — transform FX forward quotes into the implied base-currency zero-coupon quotes used for curve construction
 
 The design philosophy mirrors the rest of FinanceModels: market conventions that are a
@@ -34,6 +35,7 @@ forward(m, 1.0)  # ≈ 1.1225, and every quote reprices to zero PV
 module FX
 
 import ..AbstractModel
+import ..Bond
 import ..FinanceCore: Timepoint
 using ..FinanceCore
 
@@ -342,5 +344,118 @@ struct Converted{C, K} <: FinanceCore.AbstractContract
 end
 
 FinanceCore.maturity(c::Converted) = FinanceCore.maturity(c.contract)
+
+"""
+    FX.BasisSwapLeg(pair, cashflows)
+
+The foreign-currency leg of a constant-notional cross-currency basis swap, materialized
+into deterministic cashflows: the periodic coupons — projection-curve forward plus the
+quoted basis spread, times the accrual fraction — and the final unit principal. Amounts
+are denominated in the *base* (foreign) currency of `pair`. Produced by
+[`FX.ParBasisSwap`](@ref); see that docstring for the quoting assumptions.
+
+Because the amounts are fixed once the projection curve is known, the leg is priceable
+by any single discount curve, which is what lets par basis-swap quotes flow through the
+standard curve-fitting machinery. Under an [`FX.Forwards`](@ref) model for the same
+pair, `present_value(m, leg)` is the leg's value **in base-currency units**, priced on
+`m.foreign` (the basis-adjusted/CSA discount curve); a mismatched pair throws an
+`ArgumentError` naming both pairs.
+"""
+struct BasisSwapLeg{P <: Pair, C} <: FinanceCore.AbstractContract
+    pair::P
+    cashflows::C
+end
+
+FinanceCore.maturity(c::BasisSwapLeg) = last(c.cashflows).time
+
+function FinanceCore.present_value(m::Forwards{P}, c::BasisSwapLeg{P}, cur_time = 0.0) where {P <: Pair}
+    return FinanceCore.present_value(m.foreign, c, cur_time)
+end
+
+function FinanceCore.present_value(m::Forwards, c::BasisSwapLeg, cur_time = 0.0)
+    throw(ArgumentError("cannot price an FX.BasisSwapLeg on $(c.pair) with an FX.Forwards model for $(m.pair)"))
+end
+
+"""
+    FX.ParBasisSwap(pair, spread, maturity; reference, frequency=Periodic(4))
+
+A `Quote` for a constant-notional cross-currency basis swap struck at par: receive the
+foreign (base-currency) leg paying `reference`-curve forwards plus the quoted basis
+`spread` (a decimal, e.g. `-0.0015` for −15bp) on a unit foreign notional, pay the
+domestic (quote-currency) leg flat, with notionals exchanged at inception and
+`maturity`.
+
+Quoting assumption (standard for collateralized, OIS-discounted swaps): the domestic
+leg pays the forwards of the *same* curve used for domestic discounting, so it is worth
+par and drops out of the calibration. What remains is the base-currency par condition
+
+    Σᵢ (fᵢ + spread) * δ * DF_f(tᵢ) + DF_f(T) = 1
+
+where `fᵢ` are the (known) `reference` projection forwards, `δ` the accrual fraction,
+and `DF_f` the basis-adjusted (CSA) discount curve being calibrated. The returned quote
+is therefore `Quote(1.0, FX.BasisSwapLeg(pair, cashflows))`: a deterministic
+base-currency cashflow strip that must price to par on the curve being fit. Each coupon
+is fix-in-advance at the `reference` forward over its accrual period, exactly matching
+how [`Bond.Floating`](@ref FinanceModels.Bond.Floating) projects, so the strip equals
+the projected floating leg.
+
+Because the strip is deterministic, these quotes flow through the same `fit` methods as
+[`FX.Outright`](@ref) quotes, and the two can be mixed in a single calibration —
+forward points for the liquid short end, basis swaps for the long end:
+
+```julia
+eurusd = FX.Pair(:EUR, :USD)
+sofr = Yield.Constant(0.05)  # domestic (USD) discount curve
+estr = Yield.Constant(0.03)  # foreign (EUR) *projection* curve, already fitted
+
+quotes = [
+    FX.Outright.(eurusd, [1.1055, 1.1113], [0.25, 0.5]);
+    FX.ParBasisSwap.(eurusd, [-0.0012, -0.0018], [2.0, 5.0]; reference = estr)
+]
+m = fit(FX.Forwards(eurusd, 1.10, sofr, Spline.Cubic()), quotes, Fit.Bootstrap())
+```
+
+This is the constant-notional representation. Interbank basis swaps are quoted on the
+mark-to-market (resetting-notional) structure; under deterministic curves the two par
+spreads agree to first order. The MTM contract itself is deliberately not modeled yet —
+see the "Foreign Exchange" documentation page.
+"""
+function ParBasisSwap(pair::Pair, spread, maturity; reference, frequency = Periodic(4))
+    f = frequency.frequency
+    ts = Bond.coupon_times(maturity, f)
+    cfs = map(ts) do t
+        # fix-in-advance forward + spread, replicating `Bond.Floating`'s projection
+        # (which the FX module cannot call directly: `Projection` loads after it)
+        reference_rate = rate(frequency(forward(reference, t - 1 / f, t)))
+        coup = (reference_rate + spread) / f
+        amt = t == last(ts) ? 1.0 + coup : coup
+        Cashflow(amt, t)
+    end
+    return Quote(1.0, BasisSwapLeg(pair, cfs))
+end
+
+# Reduce one market quote to its equivalent quote on the base-currency discount curve,
+# using the spot and domestic curve carried by the model. This is the per-quote
+# primitive behind the `fit` methods for `FX.Forwards`, and is what lets a single
+# calibration mix instrument types: outright forwards for the short end, par basis
+# swaps for the long end.
+function __implied_foreign_quote(m::Forwards, q::Quote{<:Any, <:Forward})
+    c = q.instrument
+    if c.pair != m.pair
+        throw(ArgumentError("quote is for $(c.pair) but the model prices $(m.pair)"))
+    end
+    # the closed-form implied discount factor — see `implied_zcb_quotes`
+    df = (c.strike * discount(m.domestic, c.time) + q.price) / m.spot
+    return Quote(df, Cashflow(one(df), c.time))
+end
+
+# a par basis-swap leg is already denominated on the base-currency curve; only check
+# that it belongs to the model's pair
+function __implied_foreign_quote(m::Forwards, q::Quote{<:Any, <:BasisSwapLeg})
+    if q.instrument.pair != m.pair
+        throw(ArgumentError("quote is for $(q.instrument.pair) but the model prices $(m.pair)"))
+    end
+    return q
+end
 
 end

--- a/src/model/FX.jl
+++ b/src/model/FX.jl
@@ -5,7 +5,7 @@ The `FX` module provides foreign exchange models, contracts, and quote conventio
 - [`FX.Forwards`](@ref) — a covered-interest-parity model of outright FX forward rates, built from a spot rate and two discount curves
 - [`FX.Forward`](@ref) — an outright FX forward contract
 - [`FX.Converted`](@ref) — a wrapper that converts a contract's projected cashflows into the quote currency at CIP forward rates, enabling cross-currency swaps and hedged multi-currency valuation
-- [`FX.Outright`](@ref) and [`FX.ForwardPoints`](@ref) — market quote conventions, returning `Quote`s
+- [`FX.Outright`](@ref) — market forward quotes as zero-price `Quote`s
 - [`FX.ParBasisSwap`](@ref) — par cross-currency basis-swap spread quotes for calibrating the long-dated basis (with [`FX.BasisSwapLeg`](@ref) as the underlying instrument)
 - [`FX.implied_zcb_quotes`](@ref) — transform FX forward quotes into the implied base-currency zero-coupon quotes used for curve construction
 
@@ -29,7 +29,7 @@ using FinanceModels
 eurusd = FX.Pair(:EUR, :USD)
 usd = Yield.Constant(Continuous(0.05))
 
-# market outright forwards (or use FX.ForwardPoints for points quotes)
+# market outright forwards (for points quotes, convert explicitly: spot .+ points ./ scale)
 quotes = FX.Outright.(eurusd, [1.1055, 1.1113, 1.1225, 1.1459], [0.25, 0.5, 1.0, 2.0])
 
 # closed-form implied EUR discount factors, bootstrapped through a spline
@@ -236,7 +236,12 @@ nothing, so this returns a zero-price `Quote` on an [`FX.Forward`](@ref) struck 
 
 Use broadcasting to create a set of quotes: `FX.Outright.(pair, rates, times)`.
 
-See also [`FX.ForwardPoints`](@ref) for the points-over-spot convention.
+The interbank market often quotes forwards as *points* over spot in pair-specific pip
+units (`1/10_000` for most pairs, `1/100` for JPY-quoted pairs). There is deliberately
+no points constructor — a guessed scale would be the classic silent JPY error, and a
+required one would only rename the arithmetic — so convert explicitly at the data
+boundary, where the pip factor stays visible:
+`FX.Outright.(pair, spot .+ points ./ 10_000, times)`.
 
 # Examples
 
@@ -248,27 +253,6 @@ julia> q.price, q.instrument.strike, q.instrument.time
 ```
 """
 Outright(pair::Pair, forward_rate, time) = Quote(zero(forward_rate), Forward(pair, forward_rate, time))
-
-"""
-    FX.ForwardPoints(pair, points, time; spot, scale)
-
-A `Quote` for an FX forward quoted as *forward points* over spot, the interbank
-convention: the outright forward rate is `spot + points / scale`.
-
-`scale` is the pip factor and is required rather than defaulted: it is `10_000` for
-most pairs (one pip = 0.0001) but `100` for JPY-quoted pairs (one pip = 0.01), and a
-silently assumed scale is exactly the off-by-100× points error this module refuses to
-guess about. Returns the same zero-price `Quote` as [`FX.Outright`](@ref).
-
-# Examples
-
-```julia
-eurusd = FX.Pair(:EUR, :USD)
-FX.ForwardPoints(eurusd, 25.0, 0.5; spot = 1.10, scale = 10_000)               # outright 1.1025
-FX.ForwardPoints(FX.Pair(:USD, :JPY), -30.0, 1.0; spot = 150.0, scale = 100)  # outright 149.70
-```
-"""
-ForwardPoints(pair::Pair, points, time; spot, scale) = Outright(pair, spot + points / scale, time)
 
 # the closed-form implied base-currency discount factor for one forward quote:
 # DF_f(t) = (K·DF_d(t) + price)/spot. Guarded because a corrupt quote (wrong price
@@ -287,10 +271,9 @@ end
     FX.implied_zcb_quotes(quotes, spot, domestic)
     FX.implied_zcb_quotes(m::FX.Forwards, quotes)
 
-Transform FX forward `quotes` (as produced by [`FX.Outright`](@ref) /
-[`FX.ForwardPoints`](@ref)) into zero-coupon-bond `Quote`s for the *implied
-base-currency discount curve*, given the `spot` rate and the `domestic`
-(quote-currency) discount curve.
+Transform FX forward `quotes` (as produced by [`FX.Outright`](@ref)) into
+zero-coupon-bond `Quote`s for the *implied base-currency discount curve*, given the
+`spot` rate and the `domestic` (quote-currency) discount curve.
 
 Because a forward's price is `(F(t) - K) * DF_d(t)`, the implied base-currency discount
 factor at each quote's maturity is closed-form:

--- a/src/model/FX.jl
+++ b/src/model/FX.jl
@@ -57,10 +57,10 @@ the *same* pair.
 
 ```julia-repl
 julia> FX.Pair(:EUR, :USD)
-FinanceModels.FX.Pair{:EUR, :USD}()
+FX.Pair(:EUR, :USD)
 
 julia> inv(FX.Pair(:EUR, :USD))
-FinanceModels.FX.Pair{:USD, :EUR}()
+FX.Pair(:USD, :EUR)
 ```
 """
 struct Pair{B, Q} end
@@ -69,6 +69,7 @@ Pair(base::Symbol, quote_currency::Symbol) = Pair{base, quote_currency}()
 
 Base.inv(::Pair{B, Q}) where {B, Q} = Pair{Q, B}()
 Base.Broadcast.broadcastable(p::Pair) = Ref(p)
+Base.show(io::IO, ::Pair{B, Q}) where {B, Q} = print(io, "FX.Pair(:", B, ", :", Q, ")")
 
 """
     FX.Forwards(pair, spot, domestic, foreign)
@@ -146,10 +147,12 @@ currency.
 
 Under an [`FX.Forwards`](@ref) model `m` for the same pair:
 
-    present_value(m, c) = (forward(m, c.time) - c.strike) * discount(m.domestic, c.time)
+    present_value(m, c, cur_time = 0.0) = (forward(m, c.time) - c.strike) * discount(m.domestic, cur_time, c.time)
 
 A forward struck at the market outright has zero present value, which is how market
-quotes are represented — see [`FX.Outright`](@ref).
+quotes are represented — see [`FX.Outright`](@ref). A forward that settled before
+`cur_time` is worth zero, consistent with how cashflows before `cur_time` are treated
+everywhere else in the package.
 
 Pricing a contract whose pair differs from the model's pair throws an `ArgumentError`
 naming both pairs, rather than producing a silently inverted or crossed price.
@@ -175,15 +178,18 @@ end
 
 FinanceCore.maturity(c::Forward) = c.time
 
-function FinanceCore.present_value(m::Forwards{P}, c::Forward{P}) where {P <: Pair}
-    return (FinanceCore.forward(m, c.time) - c.strike) * discount(m.domestic, c.time)
+function FinanceCore.present_value(m::Forwards{P}, c::Forward{P}, cur_time = 0.0) where {P <: Pair}
+    v = (FinanceCore.forward(m, c.time) - c.strike) * discount(m.domestic, cur_time, c.time)
+    # a forward settled before the valuation time contributes nothing, matching the
+    # projection-path convention (`Filter(cf -> cf.time >= cur_time)` in Projection.jl)
+    return c.time < cur_time ? zero(v) : v
 end
 
 # a mismatched pair would otherwise fall through to the generic projection-based
 # `present_value` and fail with an unrelated-looking iteration error; name the actual
 # problem instead. The diagonal `{P,P}` method above is more specific, so matched pairs
 # never reach this.
-function FinanceCore.present_value(m::Forwards, c::Forward)
+function FinanceCore.present_value(m::Forwards, c::Forward, cur_time = 0.0)
     throw(ArgumentError("cannot price an FX.Forward on $(c.pair) with an FX.Forwards model for $(m.pair)"))
 end
 
@@ -203,7 +209,7 @@ See also [`FX.ForwardPoints`](@ref) for the points-over-spot convention.
 
 ```julia-repl
 julia> FX.Outright(FX.Pair(:EUR, :USD), 1.1225, 1.0)
-Quote{Float64, FinanceModels.FX.Forward{FinanceModels.FX.Pair{:EUR, :USD}, Float64, Float64}}(0.0, FinanceModels.FX.Forward{FinanceModels.FX.Pair{:EUR, :USD}, Float64, Float64}(FinanceModels.FX.Pair{:EUR, :USD}(), 1.1225, 1.0))
+Quote{Float64, FinanceModels.FX.Forward{FinanceModels.FX.Pair{:EUR, :USD}, Float64, Float64}}(0.0, FinanceModels.FX.Forward{FinanceModels.FX.Pair{:EUR, :USD}, Float64, Float64}(FX.Pair(:EUR, :USD), 1.1225, 1.0))
 ```
 """
 Outright(pair::Pair, forward_rate, time) = Quote(zero(forward_rate), Forward(pair, forward_rate, time))
@@ -307,6 +313,10 @@ ones and [`Bond.Floating`](@ref FinanceModels.Bond.Floating), whose reference mo
 resolved from the same store), cross-currency swaps are ordinary [`Composite`](@ref
 FinanceCore.Composite)s — see the "Foreign Exchange" documentation page for a worked
 fixed-for-fixed and floating-floating example.
+
+`maturity(::Converted)` delegates to the wrapped contract, so it is undefined
+(`MethodError`) when the wrapped contract is a transducer-modified `Eduction`: a
+transducer may alter cashflow times, so no general delegation through it is sound.
 
 # Examples
 

--- a/src/model/Model.jl
+++ b/src/model/Model.jl
@@ -16,6 +16,7 @@ include("Spline.jl")
 include("Yield.jl")
 include("Volatility.jl")
 include("Equity.jl")
+include("FX.jl")
 include("Stochastic.jl")
 
 """

--- a/test/FX.jl
+++ b/test/FX.jl
@@ -56,6 +56,13 @@
         # off-market USDEUR forward discounts on the (now-domestic) EUR curve
         K = forward(mi, 1.0) - 0.005
         @test pv(mi, FX.Forward(FX.Pair(:USD, :EUR), K, 1.0)) ≈ 0.005 * exp(-0.03)
+
+        # an exchange rate is a strictly positive price; anything else would corrupt
+        # every downstream forward, pv, and implied discount factor silently
+        @test_throws ArgumentError FX.Forwards(eurusd, 0.0, usd, eur)
+        @test_throws ArgumentError FX.Forwards(eurusd, -1.10, usd, eur)
+        @test_throws ArgumentError FX.Forwards(eurusd, NaN, usd, eur)
+        @test_throws ArgumentError FX.Forwards(eurusd, Inf, usd, eur)
     end
 
     @testset "FX.Forward contract" begin
@@ -213,7 +220,7 @@
         bond = Bond.Fixed(0.04, Periodic(2), 5.0)
 
         # each converted cashflow is the original amount times the CIP forward at its time
-        cfs = collect(Projection(FX.Converted(bond, "EURUSD"), store, CashflowProjection()))
+        cfs = collect(Projection(FX.Converted(bond, eurusd, "EURUSD"), store, CashflowProjection()))
         raw = collect(bond)
         @test length(cfs) == length(raw)
         @test all(cfs[i].time == raw[i].time for i in eachindex(raw))
@@ -221,36 +228,39 @@
 
         # fundamental identity: converting at CIP forwards then discounting on the
         # domestic curve equals discounting on the foreign curve then converting at spot
-        @test pv(usd_boot, Projection(FX.Converted(bond, "EURUSD"), store, CashflowProjection())) ≈ 1.08 * pv(eur, bond)
+        @test pv(usd_boot, Projection(FX.Converted(bond, eurusd, "EURUSD"), store, CashflowProjection())) ≈ 1.08 * pv(eur, bond)
 
         # a converted floating leg resolves its own reference curve from the same store
         frn = Bond.Floating(0.001, Periodic(4), 2.0, "ESTR")
-        lhs = pv(usd_boot, Projection(FX.Converted(frn, "EURUSD"), store, CashflowProjection()))
+        lhs = pv(usd_boot, Projection(FX.Converted(frn, eurusd, "EURUSD"), store, CashflowProjection()))
         rhs = 1.08 * pv(eur, Projection(frn, store, CashflowProjection()))
         @test lhs ≈ rhs
 
         # transducer-modified (Eduction) contracts convert too
-        scaled = pv(usd_boot, Projection(FX.Converted(bond |> Map(cf -> cf * 100.0), "EURUSD"), store, CashflowProjection()))
+        scaled = pv(usd_boot, Projection(FX.Converted(bond |> Map(cf -> cf * 100.0), eurusd, "EURUSD"), store, CashflowProjection()))
         @test scaled ≈ 100.0 * 1.08 * pv(eur, bond)
 
         # rolling the valuation date through the projection path: only cashflows at
         # or after cur_time remain, discounted from cur_time
         cur = 2.25
         manual = sum(cf.amount * forward(fx, cf.time) * discount(usd_boot, cur, cf.time) for cf in raw if cf.time >= cur)
-        @test pv(usd_boot, Projection(FX.Converted(bond, "EURUSD"), store, CashflowProjection()), cur) ≈ manual
+        @test pv(usd_boot, Projection(FX.Converted(bond, eurusd, "EURUSD"), store, CashflowProjection()), cur) ≈ manual
 
         # the identity pair converts at forward ≡ 1, letting generic multi-currency
         # code route domestic contracts through the same machinery
         idfx = FX.Forwards(FX.Pair(:USD, :USD), 1.0, usd_boot, usd_boot)
         @test forward(idfx, 2.0) == 1.0
-        @test pv(usd_boot, Projection(FX.Converted(bond, "USDUSD"), Dict("USDUSD" => idfx), CashflowProjection())) ≈ pv(usd_boot, bond)
+        @test pv(usd_boot, Projection(FX.Converted(bond, FX.Pair(:USD, :USD), "USDUSD"), Dict("USDUSD" => idfx), CashflowProjection())) ≈ pv(usd_boot, bond)
 
-        @test maturity(FX.Converted(bond, "EURUSD")) == 5.0
+        @test maturity(FX.Converted(bond, eurusd, "EURUSD")) == 5.0
         # a missing model key errors loudly
-        @test_throws KeyError collect(Projection(FX.Converted(bond, "GBPUSD"), store, CashflowProjection()))
+        @test_throws KeyError collect(Projection(FX.Converted(bond, FX.Pair(:GBP, :USD), "GBPUSD"), store, CashflowProjection()))
         # ...and so does a mis-keyed store: a yield curve where the FX model belongs
         # is named at the source instead of failing inside the transducer pipeline
-        @test_throws ArgumentError collect(Projection(FX.Converted(bond, "EURUSD"), Dict("EURUSD" => usd_boot), CashflowProjection()))
+        @test_throws ArgumentError collect(Projection(FX.Converted(bond, eurusd, "EURUSD"), Dict("EURUSD" => usd_boot), CashflowProjection()))
+        # the declared pair catches an inverted model under an otherwise-valid key —
+        # the silent reciprocal-rate conversion this wrapper exists to prevent
+        @test_throws ArgumentError collect(Projection(FX.Converted(bond, eurusd, "EURUSD"), Dict("EURUSD" => inv(fx)), CashflowProjection()))
     end
 
     @testset "textbook: fixed-for-fixed currency swap (Hull §7.9)" begin
@@ -270,7 +280,7 @@
         @test forward(fx, 2.0) ≈ 0.010047 atol = 5e-7
         @test forward(fx, 3.0) ≈ 0.010562 atol = 5e-7
 
-        yen_leg = FX.Converted(Bond.Fixed(0.05, Periodic(1), 3) |> Map(cf -> cf * 1200.0), "JPYUSD")
+        yen_leg = FX.Converted(Bond.Fixed(0.05, Periodic(1), 3) |> Map(cf -> cf * 1200.0), jpyusd, "JPYUSD")
         usd_leg = Bond.Fixed(0.08, Periodic(1), 3) |> Map(cf -> cf * -10.0)
         swap = Composite(yen_leg, usd_leg)
         p = Projection(swap, Dict("JPYUSD" => fx), CashflowProjection())
@@ -308,7 +318,7 @@
         # to −0.0677
         @test (36 * forward(fx, 1.0) - 0.4) * discount(usd25, 1.0) ≈ -0.0677 atol = 1e-4
 
-        yen_leg = FX.Converted(Bond.Fixed(0.03, Periodic(1), 3) |> Map(cf -> cf * 1200.0), "JPYUSD")
+        yen_leg = FX.Converted(Bond.Fixed(0.03, Periodic(1), 3) |> Map(cf -> cf * 1200.0), jpyusd, "JPYUSD")
         usd_leg = Bond.Fixed(0.04, Periodic(1), 3) |> Map(cf -> cf * -10.0)
         swap = Composite(yen_leg, usd_leg)
         p = Projection(swap, Dict("JPYUSD" => fx), CashflowProjection())
@@ -347,7 +357,7 @@
             # and the leg composes with FX.Converted: domestic value = spot × foreign value
             leg = qs[2].instrument
             store = Dict("EURUSD" => m_true)
-            @test pv(usd, Projection(FX.Converted(leg, "EURUSD"), store, CashflowProjection())) ≈ S * pv(csa28, leg)
+            @test pv(usd, Projection(FX.Converted(leg, eurusd, "EURUSD"), store, CashflowProjection())) ≈ S * pv(csa28, leg)
         end
 
         @testset "materialization matches Bond.Floating projection" begin
@@ -396,7 +406,7 @@
             # forwards against a spot-scaled floating USD leg — prices to zero
             T5 = tenors[2]
             swap = Composite(
-                FX.Converted(Bond.Floating(spreads[2], freq, T5, "ESTR"), "EURUSD"),
+                FX.Converted(Bond.Floating(spreads[2], freq, T5, "ESTR"), eurusd, "EURUSD"),
                 Bond.Floating(0.0, freq, T5, "SOFR") |> Map(cf -> cf * -S),
             )
             p = Projection(swap, Dict("EURUSD" => m_fit, "ESTR" => estr, "SOFR" => sofr), CashflowProjection())
@@ -423,6 +433,10 @@
             # bootstrap's distinct-maturities check rather than silently blended
             clash = [FX.Outright(eurusd, 1.12, 2.0), FX.ParBasisSwap(eurusd, -0.001, 2.0; reference = estr)]
             @test_throws ArgumentError fit(m0, clash, Fit.Bootstrap())
+            # non-whole tenors are refused: a front stub would need an accrual
+            # convention the quote constructor deliberately does not guess at
+            @test_throws ArgumentError FX.ParBasisSwap(eurusd, -0.002, 0.1; reference = estr)
+            @test_throws ArgumentError FX.ParBasisSwap(eurusd, -0.002, 2.3; reference = estr)
         end
     end
 end

--- a/test/FX.jl
+++ b/test/FX.jl
@@ -2,17 +2,16 @@
     eurusd = FX.Pair(:EUR, :USD)
 
     @testset "Pair" begin
-        @test eurusd === FX.Pair(:EUR, :USD)
-        @test inv(eurusd) === FX.Pair(:USD, :EUR)
-        @test inv(inv(eurusd)) === eurusd
+        @test eurusd == FX.Pair(:EUR, :USD)
+        @test eurusd === FX.Pair(:EUR, :USD) # immutable value: egal too
+        @test inv(eurusd) == FX.Pair(:USD, :EUR)
+        @test inv(inv(eurusd)) == eurusd
         @test repr(eurusd) == "FX.Pair(:EUR, :USD)"
 
-        # currencies are not restricted to Symbols: any isbits value works as a type
-        # parameter (e.g. InlineStrings codes, or ISO 4217 numeric codes as here),
-        # and the whole pipeline dispatches on the parametric pair
+        # currencies are not restricted to Symbols: any values work, e.g. ISO 4217
+        # numeric codes, and the whole pipeline carries them along
         iso = FX.Pair(978, 840) # EUR/USD by ISO numeric code
-        @test iso === FX.Pair{978, 840}()
-        @test inv(iso) === FX.Pair(840, 978)
+        @test inv(iso) == FX.Pair(840, 978)
         @test repr(iso) == "FX.Pair(978, 840)"
         m_iso = FX.Forwards(iso, 1.10, Yield.Constant(Continuous(0.05)), Yield.Constant(Continuous(0.03)))
         @test forward(m_iso, 1.0) ≈ 1.10 * exp(0.02)
@@ -20,6 +19,22 @@
         # a Symbol pair and an integer-code pair are distinct pairs, per the
         # direction-guard design
         @test_throws ArgumentError pv(m_iso, FX.Forward(FX.Pair(:EUR, :USD), 1.0, 1.0))
+
+        # plain strings work too (currencies are values, not type parameters)
+        s = FX.Pair("EUR", "USD")
+        @test inv(s) == FX.Pair("USD", "EUR")
+        @test repr(s) == "FX.Pair(\"EUR\", \"USD\")"
+        # equality and hashing are content-based across string storage types (the
+        # fixed widths CSV readers assign per column, or substrings as here), so
+        # contracts and models match whenever the currencies read the same
+        sub = FX.Pair(SubString("EURO", 1, 3), SubString("USDX", 1, 3))
+        @test sub == s
+        @test hash(sub) == hash(s)
+        m_str = FX.Forwards(s, 1.10, Yield.Constant(Continuous(0.05)), Yield.Constant(Continuous(0.03)))
+        @test pv(m_str, FX.Forward(sub, forward(m_str, 1.0), 1.0)) ≈ 0.0 atol = 1e-14
+        # ...but a Symbol pair and a string pair are distinct conventions
+        @test s != eurusd
+        @test_throws ArgumentError pv(m_str, FX.Forward(eurusd, 1.0, 1.0))
     end
 
     usd = Yield.Constant(Continuous(0.05))
@@ -34,9 +49,13 @@
         @test m(1.0) == forward(m, 1.0)
 
         mi = inv(m)
-        @test mi.pair === FX.Pair(:USD, :EUR)
+        @test mi.pair == FX.Pair(:USD, :EUR)
         @test forward(mi, 0.0) ≈ 1 / S
         @test forward(mi, 3.0) ≈ 1 / forward(m, 3.0)
+        # pricing under the inverted model: the role swap is complete, so an
+        # off-market USDEUR forward discounts on the (now-domestic) EUR curve
+        K = forward(mi, 1.0) - 0.005
+        @test pv(mi, FX.Forward(FX.Pair(:USD, :EUR), K, 1.0)) ≈ 0.005 * exp(-0.03)
     end
 
     @testset "FX.Forward contract" begin
@@ -67,18 +86,22 @@
         @test q.instrument.strike == 1.1225
         @test q.instrument.time == 1.0
 
-        qp = FX.ForwardPoints(eurusd, 25.0, 0.5; spot = 1.10)
+        qp = FX.ForwardPoints(eurusd, 25.0, 0.5; spot = 1.10, scale = 10_000)
         @test qp.instrument.strike ≈ 1.10 + 25 / 10_000
 
         usdjpy = FX.Pair(:USD, :JPY)
         qj = FX.ForwardPoints(usdjpy, -30.0, 1.0; spot = 150.0, scale = 100)
         @test qj.instrument.strike ≈ 149.70
 
+        # scale has no default — a silently assumed pip factor is the classic JPY
+        # off-by-100× footgun
+        @test_throws UndefKeywordError FX.ForwardPoints(eurusd, 25.0, 0.5; spot = 1.10)
+
         # pair broadcasts as a scalar
         qs = FX.Outright.(eurusd, [1.11, 1.12], [1.0, 2.0])
         @test length(qs) == 2
         @test qs[2].instrument.time == 2.0
-        qps = FX.ForwardPoints.(eurusd, [10.0, 20.0], [0.5, 1.0]; spot = 1.10)
+        qps = FX.ForwardPoints.(eurusd, [10.0, 20.0], [0.5, 1.0]; spot = 1.10, scale = 10_000)
         @test qps[1].instrument.strike ≈ 1.101
     end
 
@@ -107,6 +130,12 @@
         gbp_quote = FX.Outright(FX.Pair(:GBP, :USD), 1.25, 1.0)
         @test_throws ArgumentError FX.implied_zcb_quotes([quotes[1], gbp_quote], S, usd_boot)
         @test_throws ArgumentError FX.implied_zcb_quotes(m_true, [gbp_quote])
+
+        # a corrupt quote implying a non-positive discount factor fails at the source
+        # rather than as NaN inside a downstream spline fit
+        bad = Quote(-2.0, FX.Forward(eurusd, forward(m_true, 1.0), 1.0))
+        @test_throws ArgumentError FX.implied_zcb_quotes([bad], S, usd_boot)
+        @test_throws ArgumentError FX.__implied_foreign_quote(m_true, bad)
 
         @testset "bootstrap fit round-trip" begin
             m_fit = fit(FX.Forwards(eurusd, S, usd_boot, Spline.Cubic()), quotes, Fit.Bootstrap())
@@ -211,9 +240,24 @@
         scaled = pv(usd_boot, Projection(FX.Converted(bond |> Map(cf -> cf * 100.0), "EURUSD"), store, CashflowProjection()))
         @test scaled ≈ 100.0 * 1.08 * pv(eur, bond)
 
+        # rolling the valuation date through the projection path: only cashflows at
+        # or after cur_time remain, discounted from cur_time
+        cur = 2.25
+        manual = sum(cf.amount * forward(fx, cf.time) * discount(usd_boot, cur, cf.time) for cf in raw if cf.time >= cur)
+        @test pv(usd_boot, Projection(FX.Converted(bond, "EURUSD"), store, CashflowProjection()), cur) ≈ manual
+
+        # the identity pair converts at forward ≡ 1, letting generic multi-currency
+        # code route domestic contracts through the same machinery
+        idfx = FX.Forwards(FX.Pair(:USD, :USD), 1.0, usd_boot, usd_boot)
+        @test forward(idfx, 2.0) == 1.0
+        @test pv(usd_boot, Projection(FX.Converted(bond, "USDUSD"), Dict("USDUSD" => idfx), CashflowProjection())) ≈ pv(usd_boot, bond)
+
         @test maturity(FX.Converted(bond, "EURUSD")) == 5.0
         # a missing model key errors loudly
         @test_throws KeyError collect(Projection(FX.Converted(bond, "GBPUSD"), store, CashflowProjection()))
+        # ...and so does a mis-keyed store: a yield curve where the FX model belongs
+        # is named at the source instead of failing inside the transducer pipeline
+        @test_throws ArgumentError collect(Projection(FX.Converted(bond, "EURUSD"), Dict("EURUSD" => usd_boot), CashflowProjection()))
     end
 
     @testset "textbook: fixed-for-fixed currency swap (Hull §7.9)" begin

--- a/test/FX.jl
+++ b/test/FX.jl
@@ -135,17 +135,31 @@
         @test o_bare(m0) === m0.foreign.rate
     end
 
-    @testset "textbook: covered interest parity (Hull §5.10)" begin
-        # Hull, "Options, Futures, and Other Derivatives" (9th ed.), §5.10: with the
-        # spot AUD/USD rate at 0.6200 and 2-year continuously-compounded rates of 5%
-        # (AUD) and 7% (USD), the 2-year forward is 0.62·e^{(0.07−0.05)·2} = 0.6453.
+    @testset "textbook: covered interest parity (Hull)" begin
         audusd = FX.Pair(:AUD, :USD)
-        hull = FX.Forwards(audusd, 0.6200, Yield.Constant(Continuous(0.07)), Yield.Constant(Continuous(0.05)))
-        @test forward(hull, 2.0) ≈ 0.6453 atol = 5e-5
+        # Hull, "Options, Futures, and Other Derivatives", the parameterization used
+        # through the 9th edition (§5.10): spot 0.6200 USD per AUD and 2-year
+        # continuously-compounded rates of 5% (AUD) and 7% (USD), so the 2-year
+        # forward is 0.62·e^{(0.07−0.05)·2} = 0.6453.
+        hull9 = FX.Forwards(audusd, 0.6200, Yield.Constant(Continuous(0.07)), Yield.Constant(Continuous(0.05)))
+        @test forward(hull9, 2.0) ≈ 0.6453 atol = 5e-5
         # covered interest arbitrage: a forward struck below/above the CIP rate has
         # positive/negative value to the buyer of AUD
-        @test pv(hull, FX.Forward(audusd, 0.6300, 2.0)) > 0
-        @test pv(hull, FX.Forward(audusd, 0.6600, 2.0)) < 0
+        @test pv(hull9, FX.Forward(audusd, 0.6300, 2.0)) > 0
+        @test pv(hull9, FX.Forward(audusd, 0.6600, 2.0)) < 0
+
+        # later editions restate the same example (Example 5.6): spot 0.7500 USD per
+        # AUD, 2-year rates 3% (AUD) and 1% (USD) → forward 0.75·e^{(0.01−0.03)·2}
+        # = 0.7206, and the two covered-interest-arbitrage strategies lock in riskless
+        # profits of 21.87 and 55.79 USD at t = 2
+        hull11 = FX.Forwards(audusd, 0.7500, Yield.Constant(Continuous(0.01)), Yield.Constant(Continuous(0.03)))
+        @test forward(hull11, 2.0) ≈ 0.7206 atol = 5e-5
+        # borrow 1,000 AUD (owing 1,061.84 at t=2) and buy them forward at 0.7000
+        @test 1061.84 * (forward(hull11, 2.0) - 0.7000) ≈ 21.87 atol = 0.01
+        # borrow 1,000 USD (1,415.79 AUD once grown at 3%) and sell forward at 0.7600
+        @test 1415.79 * (0.7600 - forward(hull11, 2.0)) ≈ 55.79 atol = 0.01
+        # the contract's time-0 value is the discounted locked-in profit
+        @test 1061.84 * pv(hull11, FX.Forward(audusd, 0.7000, 2.0)) ≈ 21.87 * exp(-0.01 * 2) atol = 0.01
     end
 
     @testset "interest rate parity with periodic compounding" begin
@@ -219,5 +233,145 @@
         @test B_F ≈ 1230.55 atol = 1e-2
         # the two routes agree to numerical precision
         @test pv(usd9, p) ≈ B_F * spot - B_D
+    end
+
+    @testset "textbook: currency swap (Hull Examples 7.2 & 7.3, later editions)" begin
+        # Later editions restate the §7.9 swap with updated rates: flat 2.5% (USD) and
+        # 1.5% (JPY), continuously compounded; ¥110 = $1; receive 3% on ¥1,200M and
+        # pay 4% on $10M annually for 3 more years. Example 7.2 values it as a
+        # portfolio of FX forwards (Table forwards 0.009182 / 0.009275 / 0.009368);
+        # Example 7.3 as two bonds: B_D = $10.4191M, B_F = ¥1,252.01M, so the swap is
+        # worth 1,252.01/110 − 10.4191 ≈ $0.9629M (0.96279 unrounded; the book's
+        # printed total carries rounding).
+        jpyusd = FX.Pair(:JPY, :USD)
+        usd25 = Yield.Constant(Continuous(0.025))
+        jpy15 = Yield.Constant(Continuous(0.015))
+        spot = 1 / 110
+        fx = FX.Forwards(jpyusd, spot, usd25, jpy15)
+
+        @test forward(fx, 1.0) ≈ 0.009182 atol = 5e-7
+        @test forward(fx, 2.0) ≈ 0.009275 atol = 5e-7
+        @test forward(fx, 3.0) ≈ 0.009368 atol = 5e-7
+
+        # Example 7.2's year-1 row: net cashflow 36·F(1) − 0.4 = −0.0694 discounts
+        # to −0.0677
+        @test (36 * forward(fx, 1.0) - 0.4) * discount(usd25, 1.0) ≈ -0.0677 atol = 1e-4
+
+        yen_leg = FX.Converted(Bond.Fixed(0.03, Periodic(1), 3) |> Map(cf -> cf * 1200.0), "JPYUSD")
+        usd_leg = Bond.Fixed(0.04, Periodic(1), 3) |> Map(cf -> cf * -10.0)
+        swap = Composite(yen_leg, usd_leg)
+        p = Projection(swap, Dict("JPYUSD" => fx), CashflowProjection())
+        @test pv(usd25, p) ≈ 0.9629 atol = 2e-4
+
+        B_D = 10.0 * pv(usd25, Bond.Fixed(0.04, Periodic(1), 3))
+        B_F = 1200.0 * pv(jpy15, Bond.Fixed(0.03, Periodic(1), 3))
+        @test B_D ≈ 10.4191 atol = 1e-4
+        @test B_F ≈ 1252.01 atol = 1e-2
+        @test pv(usd25, p) ≈ B_F * spot - B_D
+    end
+
+    @testset "FX.ParBasisSwap long-end basis calibration" begin
+        sofr = fit(Spline.Linear(), ZCBYield.([0.045, 0.047, 0.048, 0.05], [1.0, 2.0, 5.0, 10.0]), Fit.Bootstrap())
+        estr = fit(Spline.Linear(), ZCBYield.([0.028, 0.03, 0.031, 0.032], [1.0, 2.0, 5.0, 10.0]), Fit.Bootstrap())
+
+        @testset "hand-derived: flat projection + flat spread" begin
+            # with an annually-paying leg off a flat 3% Periodic(1) projection curve and
+            # a −20bp spread, every coupon is 0.028, so the implied CSA curve is exactly
+            # flat 2.8% Periodic(1): DF_f(t) = 1.028^(−t)
+            ref = Yield.Constant(Periodic(0.03, 1))
+            q1 = FX.ParBasisSwap(eurusd, -0.002, 1.0; reference = ref, frequency = Periodic(1))
+            @test q1.price == 1.0
+            @test maturity(q1) == 1.0
+            @test only(q1.instrument.cashflows).amount ≈ 1.028
+
+            tenors = [1.0, 2.0, 5.0]
+            qs = [FX.ParBasisSwap(eurusd, -0.002, T; reference = ref, frequency = Periodic(1)) for T in tenors]
+            m_fit = fit(FX.Forwards(eurusd, S, usd, Spline.Linear()), qs, Fit.Bootstrap())
+            @test all(isapprox(discount(m_fit.foreign, T), 1.028^-T; atol = 1e-8) for T in tenors)
+
+            # at-market legs price to par (in base-currency units) under the true model
+            csa28 = Yield.Constant(Periodic(0.028, 1))
+            m_true = FX.Forwards(eurusd, S, usd, csa28)
+            @test all(pv(m_true, q.instrument) ≈ 1.0 for q in qs)
+            # and the leg composes with FX.Converted: domestic value = spot × foreign value
+            leg = qs[2].instrument
+            store = Dict("EURUSD" => m_true)
+            @test pv(usd, Projection(FX.Converted(leg, "EURUSD"), store, CashflowProjection())) ≈ S * pv(csa28, leg)
+        end
+
+        @testset "materialization matches Bond.Floating projection" begin
+            b = -0.0015
+            q = FX.ParBasisSwap(eurusd, b, 3.0; reference = estr)
+            frn = collect(Projection(Bond.Floating(b, Periodic(4), 3.0, "R"), Dict("R" => estr), CashflowProjection()))
+            legcfs = q.instrument.cashflows
+            @test length(legcfs) == length(frn) == 12
+            @test all(legcfs[i].time == frn[i].time for i in eachindex(frn))
+            @test all(legcfs[i].amount ≈ frn[i].amount for i in eachindex(frn))
+        end
+
+        @testset "mixed short-end forwards + long-end basis swaps" begin
+            # truth: the CSA curve is the projection curve plus a flat −18bp basis
+            basis = Yield.Constant(Continuous(-0.0018))
+            csa_true = estr + basis
+            m_true = FX.Forwards(eurusd, S, sofr, csa_true)
+            freq = Periodic(4)
+            f = freq.frequency
+
+            # the par spread each tenor must carry for the swap to be at-market on the
+            # truth curve: b = (1 − DF(T) − Σ fᵢ/f·DF(tᵢ)) / (Σ DF(tᵢ)/f)
+            tenors = [2.0, 5.0, 10.0]
+            spreads = map(tenors) do T
+                ts = Bond.coupon_times(T, f)
+                dfs = [discount(csa_true, t) for t in ts]
+                fwds = [rate(freq(forward(estr, t - 1 / f, t))) for t in ts]
+                (1 - dfs[end] - sum(fwds[i] / f * dfs[i] for i in eachindex(ts))) / (sum(dfs) / f)
+            end
+            # sanity: implied par spreads sit near the flat continuous basis
+            @test all(abs(b - -0.0018) < 2e-4 for b in spreads)
+
+            fx_qs = [FX.Outright(eurusd, forward(m_true, t), t) for t in [0.25, 0.5, 1.0]]
+            bs_qs = [FX.ParBasisSwap(eurusd, spreads[i], tenors[i]; reference = estr) for i in eachindex(tenors)]
+            # local (linear) interpolation keeps the sequential bootstrap exact for
+            # coupon-bearing quotes; a global spline (e.g. Cubic) reshapes earlier
+            # segments as later knots are added, drifting solved quotes off par
+            m_fit = fit(FX.Forwards(eurusd, S, sofr, Spline.Linear()), vcat(fx_qs, bs_qs), Fit.Bootstrap())
+
+            # both quote families reprice on the fitted model
+            @test all(abs(pv(m_fit, q.instrument)) < 1e-9 for q in fx_qs)
+            @test all(abs(pv(m_fit, q.instrument) - 1.0) < 1e-9 for q in bs_qs)
+
+            # independent cross-check through the projection machinery: the actual
+            # constant-notional basis swap — a floating EUR leg converted at the fitted
+            # forwards against a spot-scaled floating USD leg — prices to zero
+            T5 = tenors[2]
+            swap = Composite(
+                FX.Converted(Bond.Floating(spreads[2], freq, T5, "ESTR"), "EURUSD"),
+                Bond.Floating(0.0, freq, T5, "SOFR") |> Map(cf -> cf * -S),
+            )
+            p = Projection(swap, Dict("EURUSD" => m_fit, "ESTR" => estr, "SOFR" => sofr), CashflowProjection())
+            @test abs(pv(sofr, p)) < 1e-6
+        end
+
+        @testset "parametric foreign curve via generic fit" begin
+            ref = Yield.Constant(Periodic(0.03, 1))
+            qs = [FX.ParBasisSwap(eurusd, -0.002, T; reference = ref, frequency = Periodic(1)) for T in [1.0, 2.0, 3.0]]
+            m_fit = fit(FX.Forwards(eurusd, S, usd, Yield.Constant()), qs)
+            @test discount(m_fit.foreign, 1.0) ≈ 1 / 1.028 atol = 1e-6
+            @test discount(m_fit.foreign, 3.0) ≈ 1.028^-3 atol = 1e-6
+        end
+
+        @testset "guards" begin
+            gbpusd = FX.Pair(:GBP, :USD)
+            q_gbp = FX.ParBasisSwap(gbpusd, -0.001, 2.0; reference = estr)
+            m0 = FX.Forwards(eurusd, S, sofr, Spline.Cubic())
+            @test_throws ArgumentError fit(m0, [q_gbp], Fit.Bootstrap())
+            m_e = FX.Forwards(eurusd, S, sofr, estr)
+            @test_throws ArgumentError pv(m_e, q_gbp.instrument)
+            @test_throws ArgumentError pv(m_e, q_gbp.instrument, 0.5)
+            # an outright and a basis swap at the same maturity are refused by the
+            # bootstrap's distinct-maturities check rather than silently blended
+            clash = [FX.Outright(eurusd, 1.12, 2.0), FX.ParBasisSwap(eurusd, -0.001, 2.0; reference = estr)]
+            @test_throws ArgumentError fit(m0, clash, Fit.Bootstrap())
+        end
     end
 end

--- a/test/FX.jl
+++ b/test/FX.jl
@@ -370,6 +370,51 @@
             @test all(legcfs[i].amount ≈ frn[i].amount for i in eachindex(frn))
         end
 
+        @testset "front-stub tenors" begin
+            # a maturity that is not a whole number of periods forms a short first
+            # stub that accrues its actual length at the forward over [0, t₁] —
+            # compound-accrued (ParYield's stub convention), never the fabricated
+            # full-period accrual, never a negative-time lookback. Off flat 3%
+            # Periodic(1) with a −20bp spread, 0.1y quarterly is a single stub:
+            ref = Yield.Constant(Periodic(0.03, 1))
+            q = FX.ParBasisSwap(eurusd, -0.002, 0.1; reference = ref)
+            cf = only(q.instrument.cashflows)
+            @test cf.time == 0.1
+            @test cf.amount ≈ 1.0 + (1.03^0.1 - 1) - 0.002 * 0.1 # ≈ 1.00276, not 1.0069
+
+            # a longer schedule stays anchored at maturity with only the first
+            # period short (the Bond.coupon_times shape); whole periods unchanged
+            q2 = FX.ParBasisSwap(eurusd, -0.002, 2.5; reference = ref, frequency = Periodic(1))
+            cfs = q2.instrument.cashflows
+            @test [c.time for c in cfs] ≈ [0.5, 1.5, 2.5]
+            @test cfs[1].amount ≈ (1.03^0.5 - 1) - 0.002 * 0.5
+            @test cfs[2].amount ≈ 0.03 - 0.002
+
+            # the property the stub convention preserves: a zero-spread leg on its
+            # own reference curve telescopes to exactly par on any stub schedule
+            q0 = FX.ParBasisSwap(eurusd, 0.0, 2.5; reference = ref, frequency = Periodic(1))
+            @test pv(ref, q0.instrument) ≈ 1.0 atol = 1e-14
+
+            # calibration through a stub-tenor quote: the analytic par spread on a
+            # flat truth CSA curve is recovered exactly alongside whole tenors
+            csa = Yield.Constant(Periodic(0.028, 1))
+            ts2 = [0.5, 1.5, 2.5]
+            starts = [0.0, 0.5, 1.5]
+            δs = ts2 .- starts
+            dfs = [discount(csa, t) for t in ts2]
+            fwds = [(1 / discount(ref, s, t) - 1) / d for (s, t, d) in zip(starts, ts2, δs)]
+            b = (1 - dfs[end] - sum(fwds[i] * δs[i] * dfs[i] for i in 1:3)) / sum(δs[i] * dfs[i] for i in 1:3)
+            qs = [
+                FX.ParBasisSwap(eurusd, -0.002, 1.0; reference = ref, frequency = Periodic(1)),
+                FX.ParBasisSwap(eurusd, -0.002, 2.0; reference = ref, frequency = Periodic(1)),
+                FX.ParBasisSwap(eurusd, b, 2.5; reference = ref, frequency = Periodic(1)),
+            ]
+            @test all(pv(csa, q.instrument) ≈ 1.0 for q in qs)
+            m_fit = fit(FX.Forwards(eurusd, S, usd, Spline.Linear()), qs, Fit.Bootstrap())
+            @test all(abs(pv(m_fit, q.instrument) - 1.0) < 1e-9 for q in qs)
+            @test all(isapprox(discount(m_fit.foreign, t), 1.028^-t; atol = 1e-8) for t in [1.0, 2.0, 2.5])
+        end
+
         @testset "mixed short-end forwards + long-end basis swaps" begin
             # truth: the CSA curve is the projection curve plus a flat −18bp basis
             basis = Yield.Constant(Continuous(-0.0018))
@@ -433,10 +478,6 @@
             # bootstrap's distinct-maturities check rather than silently blended
             clash = [FX.Outright(eurusd, 1.12, 2.0), FX.ParBasisSwap(eurusd, -0.001, 2.0; reference = estr)]
             @test_throws ArgumentError fit(m0, clash, Fit.Bootstrap())
-            # non-whole tenors are refused: a front stub would need an accrual
-            # convention the quote constructor deliberately does not guess at
-            @test_throws ArgumentError FX.ParBasisSwap(eurusd, -0.002, 0.1; reference = estr)
-            @test_throws ArgumentError FX.ParBasisSwap(eurusd, -0.002, 2.3; reference = estr)
         end
     end
 end

--- a/test/FX.jl
+++ b/test/FX.jl
@@ -109,4 +109,101 @@
         @test discount(m_fit.foreign, 1.0) ≈ exp(-0.03) atol = 1e-6
         @test all(isapprox(forward(m_fit, t), forward(m, t); atol = 1e-6) for t in ts)
     end
+
+    @testset "foreign-curve optic composition (unbounded forms)" begin
+        # the docstring-documented unbounded 1-tuple form and a bare optic both compose
+        # through the `foreign` field (the bounded `optic => interval` form is covered
+        # via the parametric `fit` test above)
+        m0 = FX.Forwards(eurusd, 1.0, usd, eur)
+        o_tuple = FinanceModels.__fx_foreign_optic((@optic(_.rate),))
+        @test only(o_tuple)(m0) === m0.foreign.rate
+        o_bare = FinanceModels.__fx_foreign_optic(@optic(_.rate))
+        @test o_bare(m0) === m0.foreign.rate
+    end
+
+    @testset "textbook: covered interest parity (Hull §5.10)" begin
+        # Hull, "Options, Futures, and Other Derivatives" (9th ed.), §5.10: with the
+        # spot AUD/USD rate at 0.6200 and 2-year continuously-compounded rates of 5%
+        # (AUD) and 7% (USD), the 2-year forward is 0.62·e^{(0.07−0.05)·2} = 0.6453.
+        audusd = FX.Pair(:AUD, :USD)
+        hull = FX.Forwards(audusd, 0.6200, Yield.Constant(Continuous(0.07)), Yield.Constant(Continuous(0.05)))
+        @test forward(hull, 2.0) ≈ 0.6453 atol = 5e-5
+        # covered interest arbitrage: a forward struck below/above the CIP rate has
+        # positive/negative value to the buyer of AUD
+        @test pv(hull, FX.Forward(audusd, 0.6300, 2.0)) > 0
+        @test pv(hull, FX.Forward(audusd, 0.6600, 2.0)) < 0
+    end
+
+    @testset "interest rate parity with periodic compounding" begin
+        # the discrete-compounding IRP form: F(n) = S·(1+r_d)ⁿ/(1+r_f)ⁿ with
+        # annually-compounded rates
+        m1 = FX.Forwards(eurusd, 1.10, Yield.Constant(Periodic(0.02, 1)), Yield.Constant(Periodic(0.01, 1)))
+        @test forward(m1, 1.0) ≈ 1.10 * 1.02 / 1.01
+        @test forward(m1, 2.0) ≈ 1.10 * 1.02^2 / 1.01^2
+    end
+
+    @testset "FX.Converted multi-currency projection" begin
+        usd_boot = fit(Spline.Linear(), ZCBYield.([0.04, 0.045, 0.05], [1.0, 3.0, 5.0]), Fit.Bootstrap())
+        fx = FX.Forwards(eurusd, 1.08, usd_boot, eur)
+        store = Dict("EURUSD" => fx, "ESTR" => eur)
+        bond = Bond.Fixed(0.04, Periodic(2), 5.0)
+
+        # each converted cashflow is the original amount times the CIP forward at its time
+        cfs = collect(Projection(FX.Converted(bond, "EURUSD"), store, CashflowProjection()))
+        raw = collect(bond)
+        @test length(cfs) == length(raw)
+        @test all(cfs[i].time == raw[i].time for i in eachindex(raw))
+        @test all(cfs[i].amount ≈ raw[i].amount * forward(fx, raw[i].time) for i in eachindex(raw))
+
+        # fundamental identity: converting at CIP forwards then discounting on the
+        # domestic curve equals discounting on the foreign curve then converting at spot
+        @test pv(usd_boot, Projection(FX.Converted(bond, "EURUSD"), store, CashflowProjection())) ≈ 1.08 * pv(eur, bond)
+
+        # a converted floating leg resolves its own reference curve from the same store
+        frn = Bond.Floating(0.001, Periodic(4), 2.0, "ESTR")
+        lhs = pv(usd_boot, Projection(FX.Converted(frn, "EURUSD"), store, CashflowProjection()))
+        rhs = 1.08 * pv(eur, Projection(frn, store, CashflowProjection()))
+        @test lhs ≈ rhs
+
+        # transducer-modified (Eduction) contracts convert too
+        scaled = pv(usd_boot, Projection(FX.Converted(bond |> Map(cf -> cf * 100.0), "EURUSD"), store, CashflowProjection()))
+        @test scaled ≈ 100.0 * 1.08 * pv(eur, bond)
+
+        @test maturity(FX.Converted(bond, "EURUSD")) == 5.0
+        # a missing model key errors loudly
+        @test_throws KeyError collect(Projection(FX.Converted(bond, "GBPUSD"), store, CashflowProjection()))
+    end
+
+    @testset "textbook: fixed-for-fixed currency swap (Hull §7.9)" begin
+        # Hull, "Options, Futures, and Other Derivatives" (9th ed.), §7.9: flat term
+        # structures of 9% (USD) and 4% (JPY), continuously compounded; spot ¥110 = $1.
+        # An institution receives 5% on ¥1,200M and pays 8% on $10M annually for 3 more
+        # years, with principals exchanged at maturity. Hull values the swap at $1.543M
+        # two ways: as two bonds converted at spot, and as a portfolio of FX forwards.
+        jpyusd = FX.Pair(:JPY, :USD)
+        usd9 = Yield.Constant(Continuous(0.09))
+        jpy4 = Yield.Constant(Continuous(0.04))
+        spot = 1 / 110 # USD per JPY
+        fx = FX.Forwards(jpyusd, spot, usd9, jpy4)
+
+        # the forward exchange rates of Hull's Table 7.9
+        @test forward(fx, 1.0) ≈ 0.009557 atol = 5e-7
+        @test forward(fx, 2.0) ≈ 0.010047 atol = 5e-7
+        @test forward(fx, 3.0) ≈ 0.010562 atol = 5e-7
+
+        yen_leg = FX.Converted(Bond.Fixed(0.05, Periodic(1), 3) |> Map(cf -> cf * 1200.0), "JPYUSD")
+        usd_leg = Bond.Fixed(0.08, Periodic(1), 3) |> Map(cf -> cf * -10.0)
+        swap = Composite(yen_leg, usd_leg)
+        p = Projection(swap, Dict("JPYUSD" => fx), CashflowProjection())
+
+        # (a) the portfolio-of-forward-contracts valuation — our projection route
+        @test pv(usd9, p) ≈ 1.5430 atol = 1e-4
+        # (b) the two-bond valuation: B_F/110 − B_D = 1,230.55/110 − 9.6439
+        B_D = 10.0 * pv(usd9, Bond.Fixed(0.08, Periodic(1), 3))
+        B_F = 1200.0 * pv(jpy4, Bond.Fixed(0.05, Periodic(1), 3))
+        @test B_D ≈ 9.6439 atol = 1e-4
+        @test B_F ≈ 1230.55 atol = 1e-2
+        # the two routes agree to numerical precision
+        @test pv(usd9, p) ≈ B_F * spot - B_D
+    end
 end

--- a/test/FX.jl
+++ b/test/FX.jl
@@ -1,0 +1,112 @@
+@testset "FX" begin
+    eurusd = FX.Pair(:EUR, :USD)
+
+    @testset "Pair" begin
+        @test eurusd === FX.Pair(:EUR, :USD)
+        @test inv(eurusd) === FX.Pair(:USD, :EUR)
+        @test inv(inv(eurusd)) === eurusd
+    end
+
+    usd = Yield.Constant(Continuous(0.05))
+    eur = Yield.Constant(Continuous(0.03))
+    S = 1.10
+    m = FX.Forwards(eurusd, S, usd, eur)
+
+    @testset "covered interest parity forwards" begin
+        @test forward(m, 0.0) ≈ S
+        @test forward(m, 1.0) ≈ S * exp(0.05 - 0.03)
+        @test forward(m, 2.5) ≈ S * exp(0.02 * 2.5)
+        @test m(1.0) == forward(m, 1.0)
+
+        mi = inv(m)
+        @test mi.pair === FX.Pair(:USD, :EUR)
+        @test forward(mi, 0.0) ≈ 1 / S
+        @test forward(mi, 3.0) ≈ 1 / forward(m, 3.0)
+    end
+
+    @testset "FX.Forward contract" begin
+        F1 = forward(m, 1.0)
+        atm = FX.Forward(eurusd, F1, 1.0)
+        @test maturity(atm) == 1.0
+        @test pv(m, atm) ≈ 0.0 atol = 1e-14
+        # struck below the forward: worth the discounted difference in quote currency
+        @test pv(m, FX.Forward(eurusd, F1 - 0.01, 1.0)) ≈ 0.01 * exp(-0.05)
+        # pair mismatch errors loudly instead of pricing a crossed/inverted rate
+        @test_throws ArgumentError pv(m, FX.Forward(FX.Pair(:GBP, :USD), 1.0, 1.0))
+        @test_throws ArgumentError pv(m, FX.Forward(inv(eurusd), 1.0, 1.0))
+    end
+
+    @testset "quote conventions" begin
+        q = FX.Outright(eurusd, 1.1225, 1.0)
+        @test q.price == 0.0
+        @test q.instrument.strike == 1.1225
+        @test q.instrument.time == 1.0
+
+        qp = FX.ForwardPoints(eurusd, 25.0, 0.5; spot = 1.10)
+        @test qp.instrument.strike ≈ 1.10 + 25 / 10_000
+
+        usdjpy = FX.Pair(:USD, :JPY)
+        qj = FX.ForwardPoints(usdjpy, -30.0, 1.0; spot = 150.0, scale = 100)
+        @test qj.instrument.strike ≈ 149.70
+
+        # pair broadcasts as a scalar
+        qs = FX.Outright.(eurusd, [1.11, 1.12], [1.0, 2.0])
+        @test length(qs) == 2
+        @test qs[2].instrument.time == 2.0
+        qps = FX.ForwardPoints.(eurusd, [10.0, 20.0], [0.5, 1.0]; spot = 1.10)
+        @test qps[1].instrument.strike ≈ 1.101
+    end
+
+    @testset "implied zero-coupon quotes" begin
+        # a non-flat domestic curve proves DF_d enters and cancels correctly
+        usd_boot = fit(Spline.Linear(), ZCBYield.([0.04, 0.045, 0.05, 0.052], [1.0, 2.0, 5.0, 10.0]), Fit.Bootstrap())
+        m_true = FX.Forwards(eurusd, S, usd_boot, eur)
+        ts = [0.5, 1.0, 2.0, 5.0, 10.0]
+        quotes = [FX.Outright(eurusd, forward(m_true, t), t) for t in ts]
+
+        implied = FX.implied_zcb_quotes(quotes, S, usd_boot)
+        @test all(implied[i].price ≈ discount(eur, ts[i]) for i in eachindex(ts))
+        implied_m = FX.implied_zcb_quotes(m_true, quotes)
+        @test all(implied_m[i].price ≈ implied[i].price for i in eachindex(ts))
+
+        # an off-market (nonzero-price) quote implies the same discount factor
+        K = forward(m_true, 2.0) - 0.01
+        off = FX.Forward(eurusd, K, 2.0)
+        q_off = Quote(pv(m_true, off), off)
+        @test FX.implied_zcb_quotes([q_off], S, usd_boot)[1].price ≈ discount(eur, 2.0)
+
+        # mixed pairs are refused rather than blended into a meaningless curve
+        gbp_quote = FX.Outright(FX.Pair(:GBP, :USD), 1.25, 1.0)
+        @test_throws ArgumentError FX.implied_zcb_quotes([quotes[1], gbp_quote], S, usd_boot)
+        @test_throws ArgumentError FX.implied_zcb_quotes(m_true, [gbp_quote])
+
+        @testset "bootstrap fit round-trip" begin
+            m_fit = fit(FX.Forwards(eurusd, S, usd_boot, Spline.Cubic()), quotes, Fit.Bootstrap())
+            @test all(abs(pv(m_fit, q.instrument)) < 1e-10 for q in quotes)
+            @test all(isapprox(forward(m_fit, t), forward(m_true, t)) for t in ts)
+            # flat foreign truth → the interpolated curve is exact between knots too
+            @test forward(m_fit, 3.3) ≈ forward(m_true, 3.3)
+        end
+
+        @testset "all-at-once spline fit (Fit.Loss) via implied quotes" begin
+            m_fit = fit(FX.Forwards(eurusd, S, usd_boot, Spline.Cubic()), quotes)
+            @test all(abs(pv(m_fit, q.instrument)) < 1e-6 for q in quotes)
+        end
+    end
+
+    @testset "explicit cross-currency basis composition" begin
+        basis = Yield.Constant(Continuous(-0.002)) # −20bp basis on the EUR leg
+        mb = FX.Forwards(eurusd, S, usd, eur + basis)
+        @test forward(mb, 2.0) ≈ S * exp(-(0.03 - 0.002) * 2.0) / exp(-0.05 * 2.0)
+        # a negative basis cheapens base-currency discounting → higher forwards
+        @test forward(mb, 2.0) > forward(m, 2.0)
+    end
+
+    @testset "parametric foreign curve via generic fit (composed optics)" begin
+        ts = 0.5:0.5:5.0
+        quotes = [FX.Outright(eurusd, forward(m, t), t) for t in ts]
+        m_fit = fit(FX.Forwards(eurusd, S, usd, Yield.Constant()), quotes)
+        @test discount(m_fit.foreign, 1.0) ≈ exp(-0.03) atol = 1e-6
+        @test all(isapprox(forward(m_fit, t), forward(m, t); atol = 1e-6) for t in ts)
+    end
+end

--- a/test/FX.jl
+++ b/test/FX.jl
@@ -458,6 +458,67 @@
             @test abs(pv(sofr, p)) < 1e-6
         end
 
+        @testset "MTM (resetting-notional) equivalence" begin
+            # Interbank quotes use the mark-to-market structure: the flat domestic
+            # leg's notional resets to spot each period; the spread (foreign) leg
+            # stays constant. Under deterministic curves the two par spreads
+            # coincide exactly, because the resetting leg valued at CIP forwards is
+            # a telescoping strip of one-period loans, each at the domestic curve's
+            # own forward and therefore each worth par. Non-flat curves throughout
+            # so nothing cancels by accident; whole-period and front-stub schedules.
+            csa_true = estr + Yield.Constant(Continuous(-0.0018))
+            m_true = FX.Forwards(eurusd, S, sofr, csa_true)
+            for T in [5.0, 5.3]
+                ts = Bond.coupon_times(T, 4)
+                n = length(ts)
+                starts = [i == 1 ? 0.0 : ts[i - 1] for i in 1:n]
+                δs = ts .- starts
+                Fs = [forward(m_true, t) for t in ts]
+                notionals = [i == 1 ? S : Fs[i - 1] for i in 1:n] # forward(m, 0) == spot
+                d_fwds = [(1 / discount(sofr, starts[i], ts[i]) - 1) / δs[i] for i in 1:n]
+
+                # each one-period loan of the resetting leg — lend F(tᵢ₋₁) at tᵢ₋₁,
+                # receive it back with interest at the domestic curve's own forward
+                # at tᵢ — is par on its own, regardless of curve shape
+                per_period = [
+                    -notionals[i] * discount(sofr, starts[i]) +
+                        notionals[i] * (1 + d_fwds[i] * δs[i]) * discount(sofr, ts[i])
+                        for i in 1:n
+                ]
+                @test maximum(abs, per_period) < 1e-14
+
+                # ...so the whole resetting leg — interest on the resetting
+                # notional, interior reset exchanges, final notional — nets the
+                # inception exchange exactly: PV equals spot
+                leg = sum(notionals[i] * d_fwds[i] * δs[i] * discount(sofr, ts[i]) for i in 1:n) -
+                    sum((Fs[i] - notionals[i]) * discount(sofr, ts[i]) for i in 1:(n - 1)) +
+                    Fs[n - 1] * discount(sofr, ts[n])
+                @test leg ≈ S atol = 1e-12
+
+                # ...leaving exactly the constant-notional par condition: the full
+                # MTM swap priced at the constant-notional par spread is worth
+                # zero, i.e. quoted MTM spreads calibrate the constant-notional
+                # representation without approximation
+                dfs = [discount(csa_true, t) for t in ts]
+                fwds = [(1 / discount(estr, starts[i], ts[i]) - 1) / δs[i] for i in 1:n]
+                b_cn = (1 - dfs[end] - sum(fwds[i] * δs[i] * dfs[i] for i in 1:n)) /
+                    sum(δs[i] * dfs[i] for i in 1:n)
+                foreign_leg = S * (sum((fwds[i] + b_cn) * δs[i] * dfs[i] for i in 1:n) + dfs[end])
+                @test foreign_leg - leg ≈ 0.0 atol = 1e-12
+            end
+
+            # matched-pair leg pricing at a rolled valuation date delegates to the
+            # foreign curve with the same cur_time
+            q = FX.ParBasisSwap(eurusd, -0.002, 3.0; reference = estr)
+            m_par = FX.Forwards(eurusd, S, sofr, csa_true)
+            cur = 1.5
+            manual = sum(
+                cf.amount * discount(csa_true, cur, cf.time)
+                    for cf in q.instrument.cashflows if cf.time >= cur
+            )
+            @test pv(m_par, q.instrument, cur) ≈ manual
+        end
+
         @testset "parametric foreign curve via generic fit" begin
             ref = Yield.Constant(Periodic(0.03, 1))
             qs = [FX.ParBasisSwap(eurusd, -0.002, T; reference = ref, frequency = Periodic(1)) for T in [1.0, 2.0, 3.0]]

--- a/test/FX.jl
+++ b/test/FX.jl
@@ -6,6 +6,20 @@
         @test inv(eurusd) === FX.Pair(:USD, :EUR)
         @test inv(inv(eurusd)) === eurusd
         @test repr(eurusd) == "FX.Pair(:EUR, :USD)"
+
+        # currencies are not restricted to Symbols: any isbits value works as a type
+        # parameter (e.g. InlineStrings codes, or ISO 4217 numeric codes as here),
+        # and the whole pipeline dispatches on the parametric pair
+        iso = FX.Pair(978, 840) # EUR/USD by ISO numeric code
+        @test iso === FX.Pair{978, 840}()
+        @test inv(iso) === FX.Pair(840, 978)
+        @test repr(iso) == "FX.Pair(978, 840)"
+        m_iso = FX.Forwards(iso, 1.10, Yield.Constant(Continuous(0.05)), Yield.Constant(Continuous(0.03)))
+        @test forward(m_iso, 1.0) ≈ 1.10 * exp(0.02)
+        @test pv(m_iso, FX.Forward(iso, forward(m_iso, 1.0), 1.0)) ≈ 0.0 atol = 1e-14
+        # a Symbol pair and an integer-code pair are distinct pairs, per the
+        # direction-guard design
+        @test_throws ArgumentError pv(m_iso, FX.Forward(FX.Pair(:EUR, :USD), 1.0, 1.0))
     end
 
     usd = Yield.Constant(Continuous(0.05))

--- a/test/FX.jl
+++ b/test/FX.jl
@@ -86,22 +86,15 @@
         @test q.instrument.strike == 1.1225
         @test q.instrument.time == 1.0
 
-        qp = FX.ForwardPoints(eurusd, 25.0, 0.5; spot = 1.10, scale = 10_000)
-        @test qp.instrument.strike ≈ 1.10 + 25 / 10_000
-
-        usdjpy = FX.Pair(:USD, :JPY)
-        qj = FX.ForwardPoints(usdjpy, -30.0, 1.0; spot = 150.0, scale = 100)
-        @test qj.instrument.strike ≈ 149.70
-
-        # scale has no default — a silently assumed pip factor is the classic JPY
-        # off-by-100× footgun
-        @test_throws UndefKeywordError FX.ForwardPoints(eurusd, 25.0, 0.5; spot = 1.10)
-
         # pair broadcasts as a scalar
         qs = FX.Outright.(eurusd, [1.11, 1.12], [1.0, 2.0])
         @test length(qs) == 2
         @test qs[2].instrument.time == 2.0
-        qps = FX.ForwardPoints.(eurusd, [10.0, 20.0], [0.5, 1.0]; spot = 1.10, scale = 10_000)
+
+        # points quotes have no constructor (the pair-dependent pip scale must stay
+        # visible at the call site); the documented idiom is explicit arithmetic
+        points = [10.0, 20.0]
+        qps = FX.Outright.(eurusd, 1.10 .+ points ./ 10_000, [0.5, 1.0])
         @test qps[1].instrument.strike ≈ 1.101
     end
 

--- a/test/FX.jl
+++ b/test/FX.jl
@@ -5,6 +5,7 @@
         @test eurusd === FX.Pair(:EUR, :USD)
         @test inv(eurusd) === FX.Pair(:USD, :EUR)
         @test inv(inv(eurusd)) === eurusd
+        @test repr(eurusd) == "FX.Pair(:EUR, :USD)"
     end
 
     usd = Yield.Constant(Continuous(0.05))
@@ -30,10 +31,20 @@
         @test maturity(atm) == 1.0
         @test pv(m, atm) ≈ 0.0 atol = 1e-14
         # struck below the forward: worth the discounted difference in quote currency
-        @test pv(m, FX.Forward(eurusd, F1 - 0.01, 1.0)) ≈ 0.01 * exp(-0.05)
+        off = FX.Forward(eurusd, F1 - 0.01, 1.0)
+        @test pv(m, off) ≈ 0.01 * exp(-0.05)
+        # valuation at cur_time > 0: same payoff, discounted over the remaining period
+        @test pv(m, off, 0.5) ≈ 0.01 * exp(-0.05 * 0.5)
+        # inclusive at cur_time == settlement: the undiscounted payoff (matches the
+        # `cf.time >= cur_time` projection filter convention)
+        @test pv(m, off, 1.0) ≈ 0.01
+        # a forward that settled before the valuation time is worth zero
+        @test pv(m, off, 2.0) == 0.0
         # pair mismatch errors loudly instead of pricing a crossed/inverted rate
         @test_throws ArgumentError pv(m, FX.Forward(FX.Pair(:GBP, :USD), 1.0, 1.0))
         @test_throws ArgumentError pv(m, FX.Forward(inv(eurusd), 1.0, 1.0))
+        # ...including through the valuation-time form
+        @test_throws ArgumentError pv(m, FX.Forward(FX.Pair(:GBP, :USD), 1.0, 1.0), 0.5)
     end
 
     @testset "quote conventions" begin
@@ -63,6 +74,9 @@
         m_true = FX.Forwards(eurusd, S, usd_boot, eur)
         ts = [0.5, 1.0, 2.0, 5.0, 10.0]
         quotes = [FX.Outright(eurusd, forward(m_true, t), t) for t in ts]
+
+        # inv under non-flat curves: the role swap plus spot inversion is exact
+        @test forward(inv(m_true), 2.0) ≈ 1 / forward(m_true, 2.0)
 
         implied = FX.implied_zcb_quotes(quotes, S, usd_boot)
         @test all(implied[i].price ≈ discount(eur, ts[i]) for i in eachindex(ts))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ include("generic.jl")
 include("sp.jl")
 
 include("Equity.jl")
+include("FX.jl")
 include("Yield.jl")
 include("CompositeYield.jl")
 include("ZeroRatePrimitive.jl")


### PR DESCRIPTION
## Summary

Adds foreign-exchange support as a new `FX` module. The design observation: under covered interest parity, an FX forward curve is a ratio of discount factors scaled by spot —

$$F(t) = S_0 \cdot \frac{DF_f(t)}{DF_d(t)}$$

— so FX needs **no new curve mathematics**. Every existing spline, parametric model, bootstrap, curve-arithmetic operator, and `fit` path applies to FX curve construction unchanged. What this PR adds is the semantic layer where FX errors actually happen: explicit pair direction, loud failures on mismatched or inverted currencies, and market-quote constructors that refuse to guess conventions.

## What's included

- **`FX.Pair(:EUR, :USD)`** — a currency pair as a plain value struct (base/quote, matching market "EURUSD" naming); `inv` flips it. Currencies can be any values — `Symbol`s, strings (plain, `SubString`, or the InlineStrings codes CSV readers produce), or ISO 4217 numeric codes — and pairs compare by **content**: `==`/`hash` delegate to the fields, so string storage widths never split a code, while `Symbol` vs. string stays distinct. Pricing any contract against a model for a different (or inverted) pair throws an `ArgumentError` naming both pairs. Degenerate pairs (`FX.Pair(:USD, :USD)`) are deliberately allowed: the identity pair lets generic multi-currency code route domestic contracts through the same conversion machinery.
- **`FX.Forwards(pair, spot, domestic, foreign)`** — the CIP model: `forward(m, t) = spot * discount(foreign, t) / discount(domestic, t)`, callable as `m(t)`; `inv(m)` is the flipped-pair model and is calibration-exact (`forward(inv(m), t) == 1/forward(m, t)` identically, no refit). Construction requires a strictly positive, finite spot. There is deliberately no two-time `forward(m, from, to)`: under CIP the fair forward for delivery at `to` is independent of contracting time.
- **`FX.Forward(pair, strike, time)`** — outright forward contract; `pv = (F(t) − K)·DF_d(t)`, with a `cur_time` form (only the discounting date moves — the model is not rolled; settled forwards are worth zero, matching the projection filter convention).
- **`FX.Outright(pair, F, t)`** — market forwards as zero-price `Quote`s (entering at market costs nothing — the FX analog of par-bond quoting). Forward *points* deliberately have **no constructor**: a guessed pip scale is the classic silent JPY error, and a required one only renames the arithmetic, so points convert explicitly at the data boundary — `FX.Outright.(pair, spot .+ points ./ 10_000, ts)` (`1/100` for JPY-quoted pairs).
- **`FX.implied_zcb_quotes`** — the load-bearing transform: given spot and the domestic curve, each forward quote pins the implied base-currency discount factor in closed form, `DF_f(t) = (K·DF_d(t) + price)/S₀`, feeding existing curve construction (same architecture as QuantLib's `FxSwapRateHelper`, in ~10 lines). Mixed-pair sets and quotes implying non-positive/non-finite discount factors are refused with `ArgumentError`s naming the offending quote.
- **`FX.ParBasisSwap(pair, spread, maturity; reference)`** — par cross-currency basis-swap spread quotes for calibrating the long-dated basis. Under standard collateralized quoting the domestic leg pays its own discount curve flat (worth par — it drops out), so each quote materializes into a deterministic base-currency strip `Quote(1.0, FX.BasisSwapLeg(...))` against the `reference` projection curve, replicating `Bond.Floating`'s fix-in-advance projection exactly. These flow through the same `fit` methods as outrights, so **one calibration mixes forward outrights (short end) and basis swaps (long end)**. Non-whole tenors form a short first stub (the schedule stays anchored at maturity, per `Bond.coupon_times`) that accrues its *actual* length, compound-accrued in `ParYield`'s stub convention — a zero-spread leg on its own curve stays exactly par; irregular periods anywhere else are out of scope.
- **`fit` integration** — one-step `fit(FX.Forwards(pair, spot, dom, Spline.Linear()), quotes, Fit.Bootstrap())` (and `Fit.Loss`) for spline foreign curves via the per-quote implied transform; parametric foreign curves (e.g. `Yield.Constant`, NS/NSS) calibrate through the generic optimizer path via optics composed through the `foreign` field.
- **`FX.Converted(contract, pair, key)`** — cross-currency projection wrapper: converts each projected cashflow into the quote currency at the CIP forward for its time, with the FX model resolved from the projection's model store under `key` (the `Bond.Floating` key/value pattern — a converted floating leg resolves its own reference curve from the same store, so cross-currency swaps are ordinary `Composite`s). The declared `pair` is checked against the model found under the key, so an **inverted model under an otherwise-valid key errors** instead of silently converting at reciprocal rates; a non-FX model under the key is likewise named at the source.

**Present values follow one rule**: pv is denominated in the currency of the contract's own cashflows — quote currency for `FX.Forward` (it settles in quote units), base currency for `FX.BasisSwapLeg` (a base-currency strip). This preserves the package-wide repricing invariant `pv(fitted, q.instrument) ≈ q.price`; convert with spot before combining across denominations.

## Cross-currency basis / hedge pricing

The `foreign` curve is *defined by what reprices the FX market*, not as any particular reference curve, which handles the post-2008 CIP basis structurally:

- **Absorbed**: fitting to market forwards makes the fitted `foreign` curve the basis-adjusted (CSA/collateralized) discount curve — hedge pricing with the fitted model is basis-consistent by construction.
- **Explicit**: `FX.Forwards(pair, spot, usd_ois, eur_ois + basis)` via existing zero-rate curve arithmetic, and conversely `basis = m.foreign - eur_ois` extracts it as a first-class curve.

## Textbook and independent validation

- Hull (*Options, Futures, and Other Derivatives*), two editions: §5.10 CIP (AUD/USD forward 0.6453) and the later-edition Example 5.6 restatement (0.7206, both covered-interest-arbitrage profits); the §7.9 fixed-for-fixed currency swap ($1.5430M, Table 7.9 forwards, both valuation routes agreeing) and the later Examples 7.2/7.3 ($0.9629M, with the printed B_D/B_F bond values).
- Basis-swap calibration validated four independent ways: a hand-derived flat case (flat 3% − 20bp ⇒ CSA exactly flat 2.8%), an analytic par-spread round-trip on a non-flat truth curve, mixed short/long-end bootstrap repricing, and the actual composite swap (converted floating EUR leg vs. spot-scaled floating USD leg) pricing to zero through the independent projection/store machinery.

## Out of scope (documented follow-ups)

1. The mark-to-market (resetting-notional) basis-swap *contract*, pending convention decisions (settlement timing, accrual on the adjustment). Valued at CIP forwards under deterministic curves, the resetting (flat domestic) leg is a telescoping strip of one-period par loans — each at the domestic curve's own forward, each worth zero — so the constant-notional and MTM par spreads are **exactly** equal (asserted to machine precision in the test suite) and quoted MTM spreads calibrate the constant-notional representation without approximation. The two structures differ only by a convexity term on the resetting leg requiring *both* an index–discount spread on that leg *and* stochastically correlated FX and rates — the standard treatment (Fujii, Shimada & Takahashi 2010, §3.5) values the MtM leg as a portfolio of one-period swaps that is worth exactly zero when its index is the discounting rate.
2. Multi-pair consistency: independently fitted pair models are not forced to satisfy triangle arbitrage. The scaling design — documented on the FX page — is a per-currency ("collateral-consistent") market object: one spot and one curve per currency, every pair's forwards derived, `N` curves instead of up to `N(N−1)/2` pair models, with `FX.Forwards` as the pairwise view it returns.
3. Garman–Kohlhagen option methods (structurally `Equity.BlackScholesMerton(r_d, r_f, σ)`); delta-conventioned volatility surfaces; stochastic FX for `simulate`.

## Testing

- `test/FX.jl` (134 assertions): CIP forwards and inversion (including pricing under `inv(m)`), contract pricing with `cur_time` semantics, content-equality across currency representations (Symbol / String / SubString / integer ISO codes), quote conventions and broadcasting, closed-form implied-DF round-trips against a non-flat bootstrapped domestic curve, off-market quote handling, bootstrap and `Fit.Loss` spline fits, parametric fits via composed optics, explicit-basis composition, `Converted` conversion/identity/cur_time/Eduction cases, both Hull parameterizations, all four basis-swap validation routes, front-stub tenor correctness (single-stub and stub-schedule cashflows, telescoping par, and calibration through a stub-tenor quote), mark-to-market equivalence (each one-period loan of the resetting leg par to machine precision; the MTM domestic leg nets the inception exchange; the full MTM swap prices to zero at the constant-notional par spread — whole-period and stub schedules), rolled-valuation-date leg pricing, and the guard suite (pair mismatches, inverted model under a valid key, mis-keyed store, non-positive spot, `df ≤ 0` quotes, same-maturity clashes).
- Full suite green locally (Julia 1.12.5), including Aqua. Strict docs build clean; new guide page `docs/src/fx.md` + `API/FX.md`.

## Notes for review

- **Version**: bumped 6.2.0 → 6.3.0. This trivially collides with #278 (also claiming 6.3.0) on the Project.toml version line — whichever merges second takes the usual mechanical rebase.
- `FX.Forward` (contract) vs. the top-level `Forward` time-shift wrapper: name collision avoided by module qualification, consistent with `Bond.Fixed`/`Option.EuroCall` convention. `FX.Pair` shadows `Base.Pair` only *inside* the FX module (deliberate; `=>` is unaffected), following the market term "currency pair".
- No precompile-workload additions, keeping load-time impact nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
