### PR TITLE
True front-stub accrual for Bond.Fixed/Floating and the par-quote family (v6.4.0)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceModels"
 uuid = "77f2ae65-bdde-421f-ae9d-22f1af19dd76"
-version = "6.3.0"
+version = "6.4.0"
 authors = ["Alec Loudenback <alecloudenback@gmail.com> and contributors"]
 
 [deps]

--- a/docs/src/contracts.md
+++ b/docs/src/contracts.md
@@ -137,8 +137,8 @@ Another example of this is how `InterestRateSwap`[@ref] is implemented. It's sim
 
 ```julia
 function InterestRateSwap(curve, tenor; model_key="OIS")
-    fixed_rate = par(curve, tenor; frequency=4)
-    fixed_leg = Bond.Fixed(rate(fixed_rate), Periodic(4), tenor)
+    fixed_rate = Bond.__par_coupon(curve, tenor, 4) # the schedule's annualized par coupon
+    fixed_leg = Bond.Fixed(fixed_rate, Periodic(4), tenor)
     float_leg = Bond.Floating(0.0, Periodic(4), tenor, model_key) |> Map(-)
     return Composite(fixed_leg, float_leg)
 end

--- a/docs/src/fx.md
+++ b/docs/src/fx.md
@@ -333,9 +333,9 @@ both). Two practical notes:
 - A tenor that is not a whole number of coupon periods forms a *short first stub* (the
   schedule stays anchored at maturity, per `Bond.coupon_times`). The stub coupon
   accrues its actual length at the forward over `[0, t₁]`, compound-accrued so a
-  zero-spread leg on its own curve stays exactly par — `ParYield`'s stub convention.
-  `Bond.Floating` applies a full-period accrual to stubs, so the
-  strip-equals-projected-leg identity is exact for whole-period tenors.
+  zero-spread leg on its own curve stays exactly par — the same stub convention as
+  `ParYield` and `Bond.Floating`, so the strip-equals-projected-leg identity holds on
+  any front-stub schedule.
 
 Deliberately *not* built yet: the mark-to-market (resetting-notional) basis-swap
 *contract* itself, pending convention decisions (which leg resets, settlement timing,

--- a/src/Contract.jl
+++ b/src/Contract.jl
@@ -83,7 +83,7 @@ module Bond
     """
         Bond.Fixed(coupon_rate,frequency<:FinanceCore.Frequency,maturity)
 
-    An object representing a fixed coupon bond. `coupon_rate` / `frequency` is the actual payment amount.
+    An object representing a fixed coupon bond. `coupon_rate` / `frequency` is the actual payment amount for each whole coupon period. A maturity that is not a whole number of periods produces a *short first stub* (the schedule anchors at maturity and counts backward — see `Bond.coupon_times`) which accrues its actual length: the first coupon is `coupon_rate * t₁`.
 
     Note that there are a number of convienience constructors which return a Quote for a `Bond.Fixed`: 
 
@@ -116,7 +116,7 @@ module Bond
 
     """
     struct Fixed{F <: FinanceCore.Frequency, N <: Real, M <: Timepoint} <: AbstractBond
-        coupon_rate::N # coupon_rate / frequency is the actual payment amount
+        coupon_rate::N # annualized; a whole period pays coupon_rate / frequency, a short first stub pays coupon_rate * t₁
         frequency::F
         maturity::M
     end
@@ -128,7 +128,7 @@ module Bond
     """
         Bond.Floating(coupon_rate,frequency<:FinanceCore.Frequency,maturity,model_key)
 
-    An object representing a floating coupon bond. (`coupon_rate` + reference rate) / `frequency` is the actual payment amount, where the reference rate requires a `Projection` with a key/value pair where the key is the `model_key` argument and the value is the model which produces the reference rate.
+    An object representing a floating coupon bond. (`coupon_rate` + reference rate) / `frequency` is the actual payment amount for each whole coupon period, where the reference rate requires a `Projection` with a key/value pair where the key is the `model_key` argument and the value is the model which produces the reference rate. Coupons fix in advance over each accrual window. A maturity that is not a whole number of periods produces a *short first stub* (see `Bond.coupon_times`) which accrues its actual window `[0, t₁]`: the stub coupon is the reference curve's discount-factor ratio over the stub, minus one, plus `coupon_rate * t₁` — it never references a time before issue.
 
 
     See also [`FinanceCore.Quote`](@ref).
@@ -150,7 +150,7 @@ module Bond
     ```
     """
     struct Floating{F <: FinanceCore.Frequency, N <: Real, M <: Timepoint, K} <: AbstractBond
-        coupon_rate::N # coupon_rate / frequency is the actual payment amount
+        coupon_rate::N # annualized spread over the reference rate; accrues like Fixed's coupon_rate
         frequency::F
         maturity::M
         key::K
@@ -165,7 +165,7 @@ module Bond
 
     Create a `Quote` representing a par bond with the given `yield` and `maturity`. The default coupon `frequency` is semi-annual (`Periodic(2)`). If a `Rate` with `Periodic` compounding is passed, the frequency is inferred from the rate.
 
-    When `maturity ≤ 1/frequency` (i.e. the bond matures before the first regular coupon date), a stub-period par bond is created. The coupon is compound-accrued so that `(1 + stub_coupon) * discount(yield, maturity) = 1.0`, preserving par pricing. Otherwise, a standard par coupon bond `Quote` with `price = 1.0` is returned.
+    When `maturity` is not a whole number of coupon periods, the backward-anchored schedule (`Bond.coupon_times`) leaves a *short first stub* which accrues its actual length, and the coupon rate is solved so the bond prices to exactly `1.0` at the quoted yield: `c·Σᵢ δᵢ·DF(tᵢ) + DF(T) = 1`, where `δ₁ = t₁` is the stub length and `δᵢ = 1/frequency` otherwise. The sub-period case (`maturity ≤ 1/frequency`) is the single-coupon instance of this rule: the stub pays `accumulation(yield, maturity) - 1`, so `(1 + stub_coupon·maturity) * discount(yield, maturity) = 1.0`. Otherwise, a standard par coupon bond `Quote` with `price = 1.0` is returned.
 
     Use broadcasting to create a set of quotes: `ParYield.(yields, maturities)`.
 
@@ -185,11 +185,13 @@ module Bond
     end
     function ParYield(yield::Rate{N, T}, maturity; frequency = Periodic(2)) where {T <: Periodic, N}
         frequency = yield.compounding
-        coupon_period = 1 / frequency.frequency
-        coupon_rate = if maturity ≤ coupon_period
-            (accumulation(yield, maturity) - 1) * frequency.frequency
-        else
+        coupon_rate = if __regular_schedule(maturity, frequency.frequency)
             rate(yield)
+        else
+            # non-whole maturity: solve the par condition for the schedule's true
+            # accrual (short first stub, whole periods after), so the quote is
+            # exactly par at its own yield
+            __par_coupon(yield, maturity, frequency.frequency)
         end
         return Quote(1.0, Fixed(coupon_rate, frequency, maturity))
     end
@@ -225,13 +227,12 @@ module Bond
         # Assume maturity < 1 don't pay coupons and are therefore discount bonds
         # Assume maturity > 1 pay coupons and are therefore par bonds
         frequency = Periodic(2)
-        r, v = if maturity ≤ 1
-            Periodic(0.0, 1), discount(yield, maturity)
+        if maturity ≤ 1
+            return Quote(discount(yield, maturity), Fixed(0.0, Periodic(1), maturity))
         else
-            # coupon paying par bond
-            frequency(yield), 1.0
+            # coupon paying par bond; ParYield solves any front-stub schedule to par
+            return ParYield(frequency(yield), maturity)
         end
-        return Quote(v, Fixed(rate(r), r.compounding, maturity))
     end
 
     """
@@ -256,9 +257,8 @@ module Bond
         if maturity <= 1
             return Quote(discount(yield, maturity), Fixed(0.0, Periodic(1), maturity))
         else
-            frequency = Periodic(4)
-            r = frequency(yield)
-            return Quote(1.0, Fixed(rate(r), frequency, maturity))
+            # quarterly-settled par swap; ParYield solves any front-stub schedule to par
+            return ParYield(Periodic(4)(yield), maturity)
         end
     end
 
@@ -320,6 +320,34 @@ module Bond
         end
     end
     coupon_times(b::AbstractBond) = coupon_times(b.maturity, b.frequency.frequency)
+
+    """
+        __regular_schedule(maturity, frequency)
+
+    Whether `maturity` is a whole number of `1/frequency` coupon periods — i.e. the
+    backward-anchored schedule from [`coupon_times`](@ref) starts a full period after
+    issue and has no short first stub. Applies the same range-endpoint test
+    `coupon_times` uses to decide whether to drop the terminal zero, so the two
+    cannot disagree.
+    """
+    __regular_schedule(maturity, frequency) = iszero(last(maturity:(-1 / frequency):0))
+
+    """
+        __par_coupon(curve, maturity, frequency)
+
+    The annualized coupon rate `c` for which a fixed bond on the [`coupon_times`](@ref)
+    schedule — first period accruing its actual length `[0, t₁]`, whole `1/frequency`
+    periods thereafter — prices to par on `curve`: `c·Σᵢ δᵢ·DF(tᵢ) + DF(T) = 1`.
+    `curve` may be a flat `Rate` or any yield model.
+    """
+    function __par_coupon(curve, maturity, frequency)
+        ts = coupon_times(maturity, frequency)
+        annuity = sum(ts) do t
+            δ = t == first(ts) ? t : 1 / frequency
+            δ * discount(curve, t)
+        end
+        return (1 - discount(curve, maturity)) / annuity
+    end
 
 
     for op in (:ZCBPrice, :ZCBYield, :ParYield, :ParSwapYield, :CMTYield)
@@ -552,7 +580,7 @@ end
 
 A convenience method for creating an interest rate swap given a curve and a tenor via a `Composite` contract consisting of receiving a [fixed bond](@ref Bond.Fixed) and paying (i.e. the negative of) a [floating bond](@ref Bond.Floating).
 
-The notional is a unit (1.0) amount and assumed to settle four times per period.
+The notional is a unit (1.0) amount and assumed to settle four times per period. The fixed rate is the annualized par coupon for the tenor's schedule on `curve`, so the swap prices to zero at inception — including non-whole tenors, whose first period is a short stub accruing its actual length.
 
 
 A [`Projection`](@ref), with an indexable `model_key` is still needed to project a swap. See examples below for what this looks like.
@@ -567,18 +595,21 @@ julia> swap = InterestRateSwap(curve,10);
 
 julia> Projection(swap,Dict("OIS" => curve),CashflowProjection()) |> collect
 80-element Vector{Cashflow{Float64, Float64}}:
-Cashflow{Float64, Float64}(0.012272234429039353, 0.25)
-Cashflow{Float64, Float64}(0.012272234429039353, 0.5)
+Cashflow{Float64, Float64}(0.012272234429039283, 0.25)
+Cashflow{Float64, Float64}(0.012272234429039283, 0.5)
 ⋮
 Cashflow{Float64, Float64}(-0.012272234429039353, 9.75)
-Cashflow{Float64, Float64}(-1.0122722344290391, 10.0)
+Cashflow{Float64, Float64}(-1.0122722344290394, 10.0)
 
 ```
 
 """
 function InterestRateSwap(curve, tenor; model_key = "OIS")
-    fixed_rate = par(curve, tenor; frequency = 4)
-    fixed_leg = Bond.Fixed(rate(fixed_rate), Periodic(4), tenor)
+    # the annualized par coupon for the tenor's schedule (true accrual on any
+    # front stub), so the swap prices to zero at inception for any tenor —
+    # `par`'s yield quote is not the coupon on stub schedules
+    fixed_rate = Bond.__par_coupon(curve, tenor, 4)
+    fixed_leg = Bond.Fixed(fixed_rate, Periodic(4), tenor)
     float_leg = Bond.Floating(0.0, Periodic(4), tenor, model_key) |> Map(-)
     return Composite(fixed_leg, float_leg)
 end

--- a/src/Projection.jl
+++ b/src/Projection.jl
@@ -114,11 +114,20 @@ end
     b = p.contract
     ts = Bond.coupon_times(b)
     coup = b.coupon_rate / b.frequency.frequency
+    # a maturity that is not a whole number of periods leaves a short first stub
+    # (the schedule anchors at maturity and counts backward), which accrues its
+    # actual length [0, t₁] rather than paying a full period's coupon
+    first_coup = if Bond.__regular_schedule(b.maturity, b.frequency.frequency)
+        coup
+    else
+        b.coupon_rate * first(ts)
+    end
     for t in ts
+        c = t == first(ts) ? first_coup : coup
         amt = if t == last(ts)
-            1.0 + coup
+            1.0 + c
         else
-            coup
+            c
         end
         cf = Cashflow(amt, t)
         val = @next(rf, val, cf)
@@ -135,13 +144,22 @@ end
     freq = b.frequency # e.g. `Periodic(2)`
     freq_scalar = freq.frequency  # the 2 from `Periodic(2)`
     model = p.model[b.key]
+    regular = Bond.__regular_schedule(b.maturity, freq_scalar)
     for t in ts
         # Fix-in-advance: the coupon paid at t reflects the forward rate
-        # observed at the START of the accrual period [t - 1/freq, t].
+        # observed at the START of the accrual period — [t - 1/freq, t] for a
+        # whole period, [0, t₁] for the short first stub of a non-whole maturity.
         # This matches the standard market convention for FRNs and Ibor coupons,
         # and avoids referencing a rate beyond the bond's maturity for the final coupon.
-        reference_rate = rate(freq(forward(model, t - 1 / freq_scalar, t)))
-        coup = (reference_rate + b.coupon_rate) / freq_scalar
+        coup = if !regular && t == first(ts)
+            # the stub accrues its actual length: the reference part is the
+            # discount-factor ratio over the true window (never a lookback to
+            # before issue), and the spread accrues simply over the stub
+            (1 / discount(model, zero(t), t) - 1) + b.coupon_rate * t
+        else
+            reference_rate = rate(freq(forward(model, t - 1 / freq_scalar, t)))
+            (reference_rate + b.coupon_rate) / freq_scalar
+        end
         amt = if t == last(ts)
             1.0 + coup
         else

--- a/src/model/FX.jl
+++ b/src/model/FX.jl
@@ -444,8 +444,8 @@ stub), and `DF_f` the basis-adjusted (CSA) discount curve being calibrated. The
 returned quote is therefore `Quote(1.0, FX.BasisSwapLeg(pair, cashflows))`: a
 deterministic base-currency cashflow strip that must price to par on the curve being
 fit. Each coupon is fix-in-advance at the `reference` forward over its accrual period,
-exactly matching how [`Bond.Floating`](@ref FinanceModels.Bond.Floating) projects for
-whole-period tenors, so the strip equals the projected floating leg.
+exactly matching how [`Bond.Floating`](@ref FinanceModels.Bond.Floating) projects, so
+the strip equals the projected floating leg.
 
 A `maturity` that is not a whole number of periods keeps the schedule anchored at
 maturity (regular `1/frequency` periods counted backward — the shape
@@ -453,10 +453,8 @@ maturity (regular `1/frequency` periods counted backward — the shape
 coupon accrues its actual length at the forward over its true window `[0, t₁]` (never
 a negative time), compound-accrued so that a zero-spread leg on its own curve
 telescopes to exactly par — the same stub convention as
-[`ParYield`](@ref FinanceModels.Bond.ParYield)'s sub-period par bonds. This is deliberately
-more careful than `Bond.Floating`, which applies a full `1/frequency` accrual to stub
-periods, so the strip-equals-projected-leg identity above is exact for whole-period
-tenors only. Schedules irregular anywhere else (long stubs, back stubs, custom rolls)
+[`ParYield`](@ref FinanceModels.Bond.ParYield)'s stub par bonds and `Bond.Floating`'s
+stub coupons. Schedules irregular anywhere else (long stubs, back stubs, custom rolls)
 are out of scope.
 
 Because the strip is deterministic, these quotes flow through the same `fit` methods as

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -3,7 +3,7 @@ import ..AbstractModel
 import ..FinanceCore
 import ..Spline as Sp
 import ..DataInterpolations
-import ..Bond: coupon_times
+import ..Bond: coupon_times, __regular_schedule, __par_coupon
 
 using ..FinanceCore: Continuous, Periodic, discount, accumulation, forward, pv, AbstractContract
 
@@ -151,6 +151,8 @@ Calculate the par yield for maturity `time` for the given `curve` and `frequency
 
 If `time` is shorter than one regular coupon period (e.g. `time=0.5` with `frequency=1`), the single stub payment implies a compounding frequency of `1/time`: the result is quoted as `Periodic(1/time)` when `1/time` is a (near-)integer, and otherwise an `ArgumentError` is thrown because the implied frequency cannot be represented as a `Periodic` rate.
 
+If `time` is longer than one coupon period but not a whole number of periods, the schedule has a short first stub which accrues its actual length (see `Bond.coupon_times`); the result is the internal rate of return of the par-priced true-accrual schedule, quoted as `Periodic(frequency)` — so `par` of a flat curve recovers the curve's rate at any maturity. On such stub schedules this yield quote differs from the annualized par *coupon* `c` solving `c·Σᵢ δᵢ·DF(tᵢ) + DF(T) = 1`, which is what `InterestRateSwap` uses for its fixed leg.
+
 # Examples
 
 ```julia-repl
@@ -179,7 +181,15 @@ function par(curve, time; frequency = 2)
     Δt = step(coup_times)
     r = (1 - mat_disc) / coupon_pv
 
-    # Build cash flows: initial outflow of -1, then coupons r, final coupon+principal 1+r
+    # A maturity that is not a whole number of periods leaves a short first stub
+    # which accrues its actual length: such schedules pay `c·δᵢ` with the
+    # annualized coupon `c` solving the true-accrual par condition, so the IRR
+    # below is that of the correctly-accrued par-priced bond. Whole-period
+    # schedules pay `r` every period (the historical construction, unchanged).
+    stub = length(coup_times) > 1 && !__regular_schedule(time, frequency)
+    c = stub ? __par_coupon(curve, time, frequency) : r
+
+    # Build cash flows: initial outflow of -1, then coupons, final coupon+principal 1+coupon
     # Pre-allocate arrays for better performance
     n = length(coup_times)
     cfs = Vector{typeof(r)}(undef, n + 1)
@@ -189,7 +199,8 @@ function par(curve, time; frequency = 2)
     times[1] = zero(Δt)
 
     @inbounds for i in 1:n
-        cfs[i + 1] = i == n ? 1 + r : r
+        coup = stub ? c * (i == 1 ? first(coup_times) : 1 / frequency) : r
+        cfs[i + 1] = i == n ? 1 + coup : coup
         times[i + 1] = coup_times[i]
     end
 

--- a/test/FX.jl
+++ b/test/FX.jl
@@ -368,6 +368,15 @@
             @test length(legcfs) == length(frn) == 12
             @test all(legcfs[i].time == frn[i].time for i in eachindex(frn))
             @test all(legcfs[i].amount ≈ frn[i].amount for i in eachindex(frn))
+
+            # and on a front-stub schedule — the true-accrual stub convention is
+            # shared with Bond.Floating (issue #281)
+            q_stub = FX.ParBasisSwap(eurusd, b, 2.3; reference = estr)
+            frn_stub = collect(Projection(Bond.Floating(b, Periodic(4), 2.3, "R"), Dict("R" => estr), CashflowProjection()))
+            leg_stub = q_stub.instrument.cashflows
+            @test length(leg_stub) == length(frn_stub) == 10
+            @test all(leg_stub[i].time == frn_stub[i].time for i in eachindex(frn_stub))
+            @test all(leg_stub[i].amount ≈ frn_stub[i].amount for i in eachindex(frn_stub))
         end
 
         @testset "front-stub tenors" begin

--- a/test/Yield.jl
+++ b/test/Yield.jl
@@ -1,3 +1,11 @@
+# a reference model that refuses to be queried before issue — guards the floating
+# stub coupon against regressing to a negative-time lookback (issue #281)
+struct NoLookbackCurve <: FinanceModels.Yield.AbstractYieldModel end
+function FinanceCore.discount(::NoLookbackCurve, t)
+    t < 0 && error("reference curve queried at negative time $t")
+    return exp(-0.03 * t)
+end
+
 @testset "constant curve and rate -> Constant" begin
     yield = Yield.Constant(0.05)
 
@@ -136,6 +144,92 @@ end
         q_1y = ParYield(Periodic(r, 2), 1)
         @test q_1y.price == 1.0
         @test rate(q_1y.instrument.frequency(q_1y.instrument.coupon_rate)) ≈ r
+    end
+
+    @testset "front-stub schedules (true accrual)" begin
+        # a maturity that is not a whole number of periods anchors the schedule at
+        # maturity and leaves a short first stub, which accrues its actual length
+        # (issue #281): coupon_rate * t₁ for fixed coupons, the discount-factor
+        # ratio over [0, t₁] plus spread * t₁ for floating ones
+
+        @testset "Bond.Fixed stub cashflows" begin
+            cfs = Bond.Fixed(0.04, Periodic(4), 2.3) |> collect
+            @test [cf.time for cf in cfs] ≈ [0.05; 0.3:0.25:2.3]
+            @test cfs[1].amount == 0.04 * 0.05      # 0.05y of accrual, not a full quarter
+            @test all(cf.amount == 0.01 for cf in cfs[2:(end - 1)])
+            @test cfs[end].amount == 1.01
+
+            # a sub-period maturity is the single-coupon case of the same rule
+            @test only(collect(Bond.Fixed(0.04, Periodic(4), 0.05))).amount == 1.0 + 0.04 * 0.05
+        end
+
+        @testset "whole-period schedules unchanged" begin
+            cfs = Bond.Fixed(0.05, Periodic(2), 3) |> collect
+            @test all(cf.amount == 0.025 for cf in cfs[1:(end - 1)])
+            @test cfs[end].amount == 1.025
+            # non-representable period length (1/3): still the exact legacy amounts
+            cfs3 = Bond.Fixed(0.06, Periodic(3), 2) |> collect
+            @test all(cf.amount == 0.06 / 3 for cf in cfs3[1:(end - 1)])
+        end
+
+        @testset "Bond.Floating stub accrues [0, t₁], never a negative lookback" begin
+            # NoLookbackCurve (defined above) errors on any negative-time query —
+            # the old convention asked for forward(model, -0.2, 0.05) here
+            p = Projection(Bond.Floating(0.01, Periodic(4), 2.3, "k"), Dict("k" => NoLookbackCurve()), CashflowProjection())
+            cfs = collect(p)
+            @test cfs[1].amount ≈ exp(0.03 * 0.05) - 1 + 0.01 * 0.05
+            @test cfs[2].amount ≈ exp(0.03 * 0.25) - 1 + 0.01 * 0.25
+        end
+
+        @testset "zero-spread floating leg telescopes to par on any schedule" begin
+            m = fit(Spline.Linear(), ZCBYield.([0.03, 0.035, 0.041, 0.045, 0.0475], [0.5, 1.0, 2.0, 5.0, 10.0]), Fit.Bootstrap())
+            for T in [0.05, 0.6, 2.3, 5.0, 5.3]
+                p = Projection(Bond.Floating(0.0, Periodic(4), T, "k"), Dict("k" => m), CashflowProjection())
+                @test pv(m, p) ≈ 1.0 atol = 1e-14
+            end
+        end
+
+        @testset "par quotes are exactly par on stub schedules" begin
+            y = Periodic(0.04, 2)
+            flat = Yield.Constant(y)
+            for T in [1 // 4, 2.3, 5.3]
+                q = ParYield(y, T)
+                @test q.price == 1.0
+                @test pv(flat, q.instrument) ≈ 1.0 atol = 1e-14
+            end
+            # the quoted yield comes back as the bond's internal rate of return
+            @test internal_rate_of_return(ParYield(y, 2.3)) ≈ y atol = 1e-6
+            # CMT and OIS par quotes share the convention
+            @test pv(Yield.Constant(Periodic(0.045, 2)), CMTYield(0.045, 2.3).instrument) ≈ 1.0 atol = 1e-14
+            @test pv(Yield.Constant(Periodic(0.045, 4)), Bond.OISYield(0.045, 2.3).instrument) ≈ 1.0 atol = 1e-14
+
+            # bootstrap through a stub-tenor quote alongside whole tenors
+            qs = ParYield.(y, [1.0, 2.3, 4.0])
+            ms = fit(Spline.Linear(), qs, Fit.Bootstrap())
+            @test all(pv(ms, q.instrument) ≈ q.price for q in qs)
+        end
+
+        @testset "par and InterestRateSwap on stub tenors" begin
+            c = Yield.Constant(0.04)
+            # par is the IRR of the par-priced true-accrual schedule, so a flat
+            # curve's rate is recovered at any maturity, stub or not
+            @test par(c, 0.6; frequency = 4) ≈ Periodic(0.04, 1)
+            @test par(c, 2.3; frequency = 4) ≈ Periodic(0.04, 1)
+            # sub-period and whole-period behavior unchanged
+            @test par(c, 0.2; frequency = 4) ≈ Periodic(0.039374942589460726, 5)
+            @test par(c, 4) ≈ Periodic(0.03960780543711406, 2)
+            # the annualized par *coupon* is a different quantity on a stub
+            # schedule (no single compounding frequency reproduces a mixed-length
+            # schedule); it is what prices the fixed leg to par
+            cpn = FinanceModels.Bond.__par_coupon(c, 0.6, 4)
+            @test pv(c, Bond.Fixed(cpn, Periodic(4), 0.6)) ≈ 1.0 atol = 1e-14
+
+            m = fit(Spline.Linear(), ZCBYield.([0.03, 0.041, 0.045], [0.5, 2.0, 5.0]), Fit.Bootstrap())
+            for T in [0.6, 2.3, 10]
+                swap = InterestRateSwap(m, T)
+                @test abs(pv(m, Projection(swap, Dict("OIS" => m), CashflowProjection()))) < 1e-12
+            end
+        end
     end
 
     @testset "simple rate and forward" begin

--- a/test/sp.jl
+++ b/test/sp.jl
@@ -15,7 +15,8 @@ end
 
     @test collect(p) == [Cashflow(0.05, 1.0), Cashflow(0.05, 2.0), Cashflow(1.05, 3.0)]
     @test collect(c) == [Cashflow(0.05, 1.0), Cashflow(0.05, 2.0), Cashflow(1.05, 3.0)]
-    @test collect(Bond.Fixed(0.05, Periodic(1), 2.5)) == [Cashflow(0.05, 0.5), Cashflow(0.05, 1.5), Cashflow(1.05, 2.5)]
+    # non-whole maturity: the short first stub accrues its actual length (0.5y)
+    @test collect(Bond.Fixed(0.05, Periodic(1), 2.5)) == [Cashflow(0.025, 0.5), Cashflow(0.05, 1.5), Cashflow(1.05, 2.5)]
     @test collect(Bond.Fixed(0.05, Periodic(1), 1)) == [Cashflow(1.05, 1.0)]
 
     @test pv(Yield.Constant(0.05), Bond.Fixed(0.05, Periodic(1), 3.0)) ≈ 1.0


### PR DESCRIPTION
## Summary

Closes #281. `Bond.coupon_times` anchors a schedule at maturity and counts backward, so a maturity that is not a whole number of periods leaves a *short first stub* — and the projection rules paid that stub a **full period's coupon** anyway: `Bond.Fixed(0.04, Periodic(4), 2.3)` paid a full quarter's coupon for 0.05y of accrual, and `Bond.Floating` additionally referenced `forward(model, -0.2, 0.05)`, a negative-time lookback that silently extrapolated the reference curve below zero.

This PR aligns every front-stub coupon with **true accrual** — the convention `FX.ParBasisSwap` (#280) already used:

- **`Bond.Fixed`**: the stub pays `coupon_rate * t₁` (its actual length) instead of `coupon_rate / frequency`.
- **`Bond.Floating`**: the stub fixes in advance over its true window `[0, t₁]` — the reference part is the discount-factor ratio over the stub (`1/DF(0,t₁) − 1`, never a query before issue), plus `coupon_rate * t₁` of spread accrual.
- **`ParYield` / `ParSwapYield`**: on any non-whole maturity the coupon is solved from the par condition `c·Σᵢ δᵢ·DF(tᵢ) + DF(T) = 1` at the quoted flat yield, so the quote is **exactly par at its own yield** (previously true only for whole schedules and the `maturity ≤ 1/frequency` special case — which is now just the single-coupon instance of the general rule).
- **`CMTYield` / `OISYield`**: their par-bond branches now route through `ParYield`, inheriting the same guarantee.
- **`par(curve, time)`**: for multi-period stub schedules, IRRs the **true-accrual** par bond instead of the full-coupon-stub one. Its rate-coherence property is preserved — `par` of a flat curve recovers the curve's rate at any maturity (the existing tests pinning this pass unchanged, and `par(Constant(0.04), 0.6; frequency=4)` returns the *identical* value as before, since either convention's par bond prices to 1.0 on the flat curve). On a stub schedule the yield quote and the annualized par *coupon* are genuinely different quantities (no single compounding frequency reproduces a mixed-length schedule), so:
- **`InterestRateSwap`**: derives its fixed coupon from the par-condition solve (`Bond.__par_coupon`) rather than `rate(par(...))`. A stub-tenor swap now prices to zero (~1e-16; previously off by the accrual mismatch), and whole-tenor fixed coupons shed the IRR round-trip's solver noise (a ~1e-16 relative shift, e.g. the docstring's `0.012272234429039353` → `0.012272234429039283`).

One implementation carries all of it: `Bond.__regular_schedule` (whole-number-of-periods test, using the same range-endpoint check `coupon_times` itself applies, so they cannot disagree) and `Bond.__par_coupon` (the par-condition solve, valid for flat `Rate`s and full curves alike).

## What does *not* change

- **Whole-period schedules are bit-identical** — the regular-period formulas are literally untouched code paths, asserted down to non-representable period lengths (`Periodic(3)` coupons still exactly `0.06/3`).
- `par`'s sub-period convention (`Periodic(1/time)` quoting) and whole-period IRR path: unchanged to the bit.
- Zero-coupon quotes (`ZCBYield`/`ZCBPrice`, `CMTYield`/`OISYield` ≤ 1y): unaffected.
- The *paid amount* of a `ParYield` sub-period stub: still `accumulation(yield, m) − 1`; only the quoted `coupon_rate` field's convention moves (from `(A−1)·f` to `(A−1)/m`, matching what the projection now multiplies by).

## Migration note (behavioral change → v6.4.0)

Anyone projecting **non-whole-maturity** bonds gets different (correct) cashflows:

- `Bond.Fixed(0.04, Periodic(4), 2.3)`: first coupon `0.002` (= 0.04·0.05), was `0.01`.
- `Bond.Floating(...)` stub coupons no longer depend on the reference curve's negative-time extrapolation.
- `ParYield`/`CMTYield`/`OISYield` on stub tenors: quoted coupon values move accordingly; every such quote now reprices to exactly `1.0` on its own yield, which also makes bootstraps through stub tenors exact. `par` on stub tenors moves only for non-flat curves (the IRR now reflects the correctly-accrued bond).

Whole-number tenors — the overwhelmingly common case — are unchanged to the bit.

## Consequences picked up for free

- A zero-spread floating leg on its own curve telescopes to **exactly par on any front-stub schedule** (`Σ (DF(tᵢ₋₁)/DF(tᵢ) − 1)·DF(tᵢ) + DF(T) = 1`), asserted at 1e-14 on non-flat bootstrapped curves.
- `FX.ParBasisSwap`'s materialized strip now equals the projected `Bond.Floating` leg on stub schedules too (previously whole tenors only); the invariant test is extended and the #280 docs noting the divergence are updated.

## Testing

New `"front-stub schedules (true accrual)"` testset: exact stub cashflow values for `Bond.Fixed` (multi-period and sub-period); whole-schedule bit-identity (including `Periodic(3)`); a `NoLookbackCurve` reference model that *errors* on any negative-time query, pinning the floating stub regression; telescoping-par for five schedule shapes on a non-flat curve; par-exactness of `ParYield`/`CMTYield`/`OISYield` stub quotes plus IRR round-trip and bootstrap-through-stub-tenor; `par` flat-recovery at stub tenors alongside unchanged sub-period/whole pins; the stub par *coupon* pricing a fixed leg to par; `InterestRateSwap` ≈ 0 at stub and whole tenors on a non-flat curve. FX materialization-invariant extended to a stub tenor. Full suite + Aqua green locally; strict docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
