### PR TITLE
Consolidate the precompile workload

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,36 +1,35 @@
-using PrecompileTools    # this is a small dependency
-
+using PrecompileTools
 
 @setup_workload begin
-    # Putting some things in `@setup_workload` instead of `@compile_workload` can reduce the size of the
-    # precompile file and potentially make loading faster.
-
+    rates = [0.01, 0.02, 0.03]
+    times = [0.0, 1.0, 2.0, 3.0]
+    curve_rates = [first(rates); rates]
+    q_rate = ZCBYield(rates)
 
     @compile_workload begin
-        # all calls in this block will be precompiled, regardless of whether
-        # they belong to your package or not (on Julia 1.8 and higher)
-
-
-        q_rate = ZCBYield([0.01, 0.02, 0.03])
+        # Cover the public quote constructors separately because q_rate was
+        # deliberately created in setup (and therefore is not traced).
+        ZCBYield(rates)
         ZCBPrice(0.9, 1.0)
         ParYield(0.9, 1.0)
         CMTYield(0.9, 1.0)
 
-        # bootstrap a linear spline yield model
+        # One representative curve is enough to compile the bootstrap/root-find
+        # machinery. The remaining interpolants only need their constructors
+        # traced; running a complete bootstrap for each one repeats the same
+        # end-to-end root-finding workflow during package precompilation.
         model_rate = fit(Spline.Linear(), q_rate, Fit.Bootstrap())
-        fit(Spline.Quadratic(), q_rate, Fit.Bootstrap())
-        fit(Spline.Cubic(), q_rate, Fit.Bootstrap())
-        model_rate = fit(Spline.Linear(), q_rate)
-        fit(Spline.Quadratic(), q_rate)
-        fit(Spline.Cubic(), q_rate)
-        fit(Spline.BSpline(3), q_rate, Fit.Bootstrap())  # keep the (opt-in) global B-spline path precompiled
+        Yield.Spline(Spline.Quadratic(), times, curve_rates)
+        Yield.Spline(Spline.Cubic(), times, curve_rates)
+        Yield.Spline(Spline.BSpline(3), times, curve_rates)
+
+        # Retain one spline fit and one generic optic-based fit so both core
+        # Optimization/AD dispatch paths remain warm without repeating them for
+        # every interpolation implementation.
+        fit(Spline.Linear(), q_rate)
         fit(Yield.NelsonSiegelSvensson(), q_rate)
 
-
         present_value(model_rate, Cashflow(1.0, 1.0))
-
         first(q_rate).instrument |> collect
-
-
     end
 end


### PR DESCRIPTION
## Summary

- move workload inputs into `@setup_workload`
- retain one representative bootstrap/root-finding workflow
- construct quadratic, cubic, and opt-in B-spline interpolants directly instead of repeating full fits
- retain both core optimization paths: a spline-specific fit and the generic optic-based NSS fit

## Rationale

Optimization-backed fitting remains core functionality. This change therefore keeps representative optimizer and AD coverage while avoiding repeated end-to-end solves for interpolation implementations whose constructor coverage is sufficient.

Linear, quadratic, and cubic spline tags share the same `PolynomialSpline` type, so Julia already deduplicates much of their compiled code. Isolated measurements consequently show approximately neutral package-image size (~26 MiB) and precompile time (~10 s). This PR is intentionally a workload consolidation and maintenance improvement rather than claiming a large load-time win.

## Verification

- `Pkg.precompile()`
- direct smoke tests for spline and Nelson-Siegel-Svensson optimizer fits
- full `Pkg.test()` suite: 3,285 tests passed
- `git diff --check`