### PR TITLE
Support DataInterpolations 9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ FinanceModelsUnicodePlots = "UnicodePlots"
 [compat]
 AccessibleModels = "0.1"
 Accessors = "^0.1"
-DataInterpolations = "8"
+DataInterpolations = "8, 9"
 DifferentiationInterface = "0.7.4"
 FinanceCore = "2.3, 3"
 IntervalSets = "^0.7"

--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ FinanceModelsUnicodePlots = "UnicodePlots"
 [compat]
 AccessibleModels = "0.1"
 Accessors = "^0.1"
-DataInterpolations = "8, 9"
+DataInterpolations = "9"
 DifferentiationInterface = "0.7.4"
 FinanceCore = "2.3, 3"
 IntervalSets = "^0.7"

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -81,7 +81,13 @@ function Spline(b::Sp.BSpline, xs, ys)
         :Average
     end
 
-    return Spline(DataInterpolations.BSplineInterpolation(ys, xs, order, :Uniform, knot_type; extrapolation = DataInterpolations.ExtrapolationType.Extension))
+    interpolation = if pkgversion(DataInterpolations) >= v"9"
+        DataInterpolations.BSplineInterpolation(ys, xs, order, knot_type; extrapolation = DataInterpolations.ExtrapolationType.Extension)
+    else
+        DataInterpolations.BSplineInterpolation(ys, xs, order, :Uniform, knot_type; extrapolation = DataInterpolations.ExtrapolationType.Extension)
+    end
+
+    return Spline(interpolation)
 end
 
 function Spline(::Sp.PCHIP, xs, ys)

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -81,13 +81,7 @@ function Spline(b::Sp.BSpline, xs, ys)
         :Average
     end
 
-    interpolation = if pkgversion(DataInterpolations) >= v"9"
-        DataInterpolations.BSplineInterpolation(ys, xs, order, knot_type; extrapolation = DataInterpolations.ExtrapolationType.Extension)
-    else
-        DataInterpolations.BSplineInterpolation(ys, xs, order, :Uniform, knot_type; extrapolation = DataInterpolations.ExtrapolationType.Extension)
-    end
-
-    return Spline(interpolation)
+    return Spline(DataInterpolations.BSplineInterpolation(ys, xs, order, knot_type; extrapolation = DataInterpolations.ExtrapolationType.Extension))
 end
 
 function Spline(::Sp.PCHIP, xs, ys)


### PR DESCRIPTION
## Summary
- require DataInterpolations 9
- update the B-spline constructor for the DataInterpolations 9 API

## Testing
- `julia --project=@temp --startup-file=no -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.add(PackageSpec(name="DataInterpolations", version="9")); Pkg.test("FinanceModels")'` (DataInterpolations 9.2.0)