### PR TITLE
ZeroRateCurve: read-only owned storage, validated constructor, Accessors-safe cache

### DIFF
--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -1,5 +1,18 @@
 # Migration Guide
 
+## v6.4 to v6.5
+
+!!! warning "New errors from `ZeroRateCurve` construction"
+    `ZeroRateCurve` now owns its data and validates its inputs. Inputs that previously produced silently wrong curves (`NaN` discount factors from duplicate tenors, misordered knots with `MonotoneConvex`, stale interpolation caches after `@set`) are now loud `ArgumentError`s or cannot happen at all.
+
+- **`ZeroRateCurve` copies `rates`/`tenors` into owned storage** and promotes them to one concrete floating-point type (`Int` tenors become `Float64`; `Float32`+`BigFloat` → `BigFloat`; `Float64`+`ForwardDiff.Dual` → `Dual`; ranges and tuples are accepted). Mutating the vectors you passed in no longer affects the curve.
+- **`zrc.rates` and `zrc.tenors` are read-only.** Indexed assignment (`zrc.rates[1] = …`, `.=`, `sort!`, writes through `view`) throws an `ArgumentError`. Use `copy(zrc.rates)` for a mutable copy, and `Accessors.@set zrc.rates[i] = x` / `@set zrc.tenors = grid` / `@set zrc.spline = …` to derive a modified curve — these now re-validate and **rebuild the interpolation cache** (previously `@set` silently kept the stale interpolant, so two curves could be `==` yet price differently).
+- **The interpolation cache is internal**: `propertynames(zrc)` is `(:rates, :tenors, :spline)`, `zrc._model` throws, and `@set zrc._model = …` throws. The undocumented 4-argument `ZeroRateCurve(rates, tenors, spline, model)` constructor is removed; `ConstructionBase.setproperties`/`constructorof` reconstruct correctly through the 3-argument form.
+- **Validation** — `ArgumentError` when `rates` and `tenors` differ in length or are empty; when any rate or tenor is non-finite (`NaN`, `±Inf`); when any tenor is negative; when tenors are not strictly increasing (unsorted or duplicated); or when there are fewer knots than the interpolant needs — **`Spline.PCHIP()` and `Spline.Akima()` 3; `Spline.Linear()`/`Quadratic()`/`Cubic()`/`BSpline(n)` 2; `Spline.MonotoneConvex()` 1**. `Spline.BSpline(d)`/`Spline.PolynomialSpline(d)` now require `d ≥ 1` at construction. Negative rates and a `t = 0` knot in the direct form remain valid.
+- **The direct form no longer sorts unsorted tenors** (it throws); the `ZeroRateCurve(curve::AbstractYieldModel, tenors)` sampling form still sorts its tenor grid, still requires `t > 0`, and now samples through `zero(curve, t)` instead of `-log(discount(curve, t))/t`, which is numerically stable at very small and very large tenors.
+- `isequal(::ZeroRateCurve, ::ZeroRateCurve)` is now fieldwise (previously it fell back to `==`), so `isequal(a, b)` implies `hash(a) == hash(b)`; `ZeroRateCurve([-0.0], t)` and `ZeroRateCurve([0.0], t)` are `==` but not `isequal`, exactly like the underlying arrays.
+- `fit(zrc::ZeroRateCurve, quotes)` is now supported (one bounded optic per knot rate, as for `Yield.MonotoneConvex`).
+
 ## v6.0 to v6.1
 
 !!! warning "Changed numbers and new errors"

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -123,6 +123,30 @@ __default_optic(m::Yield.MonotoneConvex) = ntuple(i -> (@optic(_.rates[i]) => -1
 # stored rates/times, which recomputes the cache and keeps `f`/`fᵈ` consistent.
 Accessors.ConstructionBase.constructorof(::Type{<:Yield.MonotoneConvex}) =
     (f, fᵈ, rates, times) -> Yield.MonotoneConvex(rates, times)
+
+# One bounded optic per knot rate, as for `MonotoneConvex`.
+__default_optic(m::Yield.ZeroRateCurve) = ntuple(i -> (@optic(_.rates[i]) => -1.0 .. 1.0), length(m.rates))
+
+# ConstructionBase protocol for `ZeroRateCurve`, a struct with a derived cache (`_model`):
+#  * the public properties are (rates, tenors, spline) — `getproperties` excludes the cache;
+#  * `setproperties` re-validates and rebuilds through the single constructor and REJECTS a
+#    patch to `_model` (or any unknown key) rather than silently ignoring it, so
+#    `setproperties(z, getproperties(z)) == z` and `Accessors.mapproperties(identity, z) == z`;
+#  * the raw `constructorof` closure (same shape as the MonotoneConvex one) discards the cache
+#    argument and rebuilds, satisfying `constructorof(typeof(z))(getfields(z)...) == z`
+#    without introducing a public 4-arg constructor.
+# Every `@set`/`setall`/`fit` reconstruction therefore recomputes the cache; it can never go stale.
+Accessors.ConstructionBase.getproperties(z::Yield.ZeroRateCurve) =
+    (rates = z.rates, tenors = z.tenors, spline = z.spline)
+function Accessors.ConstructionBase.setproperties(z::Yield.ZeroRateCurve, patch::NamedTuple)
+    all(k -> k in (:rates, :tenors, :spline), keys(patch)) || throw(ArgumentError(
+        "ZeroRateCurve: only `rates`, `tenors` and `spline` can be set (got $(keys(patch))); " *
+        "the interpolation cache is derived from them and rebuilt automatically."))
+    return Yield.ZeroRateCurve(
+        get(patch, :rates, z.rates), get(patch, :tenors, z.tenors), get(patch, :spline, z.spline))
+end
+Accessors.ConstructionBase.constructorof(::Type{<:Yield.ZeroRateCurve}) =
+    (rates, tenors, spline, _model) -> Yield.ZeroRateCurve(rates, tenors, spline)
 __default_optic(m::Yield.NelsonSiegel) = (
         @optic(_.τ₁) => 0.0 .. 100.0,
         @optic(_.β₀) => -10.0 .. 10.0,

--- a/src/model/Spline.jl
+++ b/src/model/Spline.jl
@@ -55,6 +55,10 @@ return `PolynomialSpline(1/2/3)`.
 """
 struct PolynomialSpline <: SplineCurve
     order::Int
+    function PolynomialSpline(order::Integer)
+        order >= 1 || throw(ArgumentError("Spline.PolynomialSpline: order must be ≥ 1 (got $order)."))
+        return new(order)
+    end
 end
 
 """
@@ -78,6 +82,10 @@ they build faster, have better key-rate locality, and are thread-safe.
 """
 struct BSpline <: SplineCurve
     order::Int
+    function BSpline(order::Integer)
+        order >= 1 || throw(ArgumentError("Spline.BSpline: order must be ≥ 1 (got $order)."))
+        return new(order)
+    end
 end
 
 """

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -2,6 +2,7 @@ module Yield
 import ..AbstractModel
 import ..FinanceCore
 import ..Spline as Sp
+import ..ReadOnlyVector
 import ..DataInterpolations
 import ..Bond: coupon_times, __regular_schedule, __par_coupon
 

--- a/src/model/Yield/ZeroRateCurve.jl
+++ b/src/model/Yield/ZeroRateCurve.jl
@@ -8,16 +8,16 @@ with interpolation between tenors via the existing `Spline` infrastructure.
 The `spline` argument is a `Spline.SplineCurve` object (e.g. `Spline.MonotoneConvex()`,
 `Spline.PCHIP()`, `Spline.Linear()`, `Spline.Cubic()`). Defaults to `Spline.MonotoneConvex()`.
 
-The curve stores the raw `rates` vector, making it compatible with ForwardDiff:
-construct `ZeroRateCurve(dual_rates, tenors, spline)` inside an AD closure and
-the interpolation will propagate dual numbers.
+The curve stores the `rates` vector with its original element type, making it compatible
+with ForwardDiff: construct `ZeroRateCurve(dual_rates, tenors, spline)` inside an AD closure
+and the interpolation will propagate dual numbers.
 
 ## Constructing from another yield model
 
 The second form samples zero rates from any `AbstractYieldModel` (e.g. `Yield.Constant`,
 `Yield.NelsonSiegel`, a fitted spline curve, etc.) at the specified `tenors`, producing
 a `ZeroRateCurve` suitable for key rate analysis with ActuaryUtilities.jl. All tenors
-must be positive (`t > 0`).
+must be positive (`t > 0`); they are sorted before sampling.
 
 # Examples
 
@@ -41,14 +41,48 @@ ns = Yield.NelsonSiegel(1.0, 0.04, -0.02, 0.01)
 zrc_ns = ZeroRateCurve(ns, [1.0, 2.0, 5.0, 10.0, 20.0])
 ```
 
+## Storage and validation
+
+The curve **owns** its data: `rates` and `tenors` are copied at construction (so later
+mutation of the vectors you passed in does not affect the curve) and promoted to a single
+concrete floating-point element type (`Int` → `Float64`, `Float32` + `BigFloat` → `BigFloat`,
+`Float64` + `ForwardDiff.Dual` → `Dual`). Ranges and tuples are accepted. The public
+properties are `rates`, `tenors` and `spline`; the first two are exposed as **read-only**
+vectors — indexed assignment (`zrc.rates[1] = …`, `.=`, `sort!`, …) throws. Use
+`copy(zrc.rates)` for a mutable copy. The interpolation cache is internal and not accessible.
+
+Construction throws an `ArgumentError` when:
+
+- `rates` and `tenors` differ in length, or either is empty;
+- any rate or tenor is not finite (`NaN`, `±Inf`);
+- any tenor is negative, or the tenors are not strictly increasing (unsorted or duplicated);
+- there are fewer knots than the interpolant needs: `Spline.PCHIP()` and `Spline.Akima()`
+  need 3, `Spline.Linear()`/`Quadratic()`/`Cubic()`/`BSpline(n)` need 2,
+  `Spline.MonotoneConvex()` needs 1.
+
+A tenor of `0` is allowed in the direct form (you supply the instantaneous rate `r(0)`
+explicitly); negative rates are allowed.
+
+To change a curve, use `Accessors.@set`, which re-validates and rebuilds the interpolation:
+
+```julia
+using Accessors
+zrc2 = @set zrc.rates[2] = 0.031          # one knot rate
+zrc3 = @set zrc.tenors = [1.0, 3.0, 6.0, 12.0]  # whole grid (must stay strictly increasing)
+zrc4 = @set zrc.spline = Spline.Linear()  # different interpolant over the same knots
+```
+
+`fit(zrc, quotes)` is supported, with one bounded optic per knot rate (as for
+`Yield.MonotoneConvex`).
+
 ## Performance note
 
 The interpolation model is built once at construction (`Yield.build_model(spline,
 tenors, rates)`) and stored on the struct, so `discount` is a direct dispatch to
 the prebuilt model rather than a rebuild per call. AD usage that creates a fresh
 `ZeroRateCurve` per gradient step (the documented pattern) pays the build cost
-once per step — same total cost as before, just front-loaded from `discount`-time
-to construction-time. The `_model` field is internal; do not rely on it.
+once per step. The cache is a pure function of `(rates, tenors, spline)` and is ignored
+by `==`, `isequal` and `hash`.
 
 ## Forward curve smoothness
 
@@ -57,30 +91,98 @@ and produces C1-smooth forward curves ([Hagan & West, 2006](https://doi.org/10.1
 For C2 smoothness, use `Spline.Cubic()`. `Spline.Linear()` produces kinks in the
 forward curve at tenor points.
 """
-struct ZeroRateCurve{R<:AbstractVector, T<:AbstractVector, S<:Sp.SplineCurve, M} <: AbstractYieldModel
-    rates::R      # continuously-compounded zero rates
-    tenors::T     # time points
-    spline::S     # e.g., Spline.Linear(), Spline.Cubic()
-    _model::M     # prebuilt interpolation; do not access directly
-end
+struct ZeroRateCurve{R, T, S <: Sp.SplineCurve, M} <: AbstractYieldModel
+    rates::ReadOnlyVector{R}   # continuously-compounded zero rates (finite); read-only
+    tenors::ReadOnlyVector{T}  # finite, ≥ 0, strictly increasing; read-only
+    spline::S                  # e.g., Spline.Linear(), Spline.MonotoneConvex()
+    _model::M                  # pure function of (rates, tenors, spline); internal, not settable
 
-# Three-arg constructor eagerly builds the interpolation. The 4-arg form
-# (passing a prebuilt `_model`) is internal — used to thread an already-built
-# model through wrapping constructors without rebuilding.
-function ZeroRateCurve(rates, tenors, spline)
-    model = Yield.build_model(spline, tenors, rates)
-    return ZeroRateCurve(rates, tenors, spline, model)
+    # The only constructor. Copies and promotes the inputs, validates them, builds the
+    # interpolation cache, and wraps the storage read-only — so `_model` can never disagree
+    # with `(rates, tenors, spline)`. There is deliberately no 4-arg constructor:
+    # Accessors/ConstructionBase reconstruct through `setproperties`/`constructorof`
+    # (see src/fit.jl), both of which route back here.
+    function ZeroRateCurve(rates, tenors, spline::Sp.SplineCurve)
+        r = __owned_float_vector(rates, "rates")
+        t = __owned_float_vector(tenors, "tenors")
+        length(r) == length(t) || throw(ArgumentError(
+            "ZeroRateCurve: `rates` and `tenors` must have the same length (got $(length(r)) and $(length(t)))."))
+        all(isfinite, r) || throw(ArgumentError("ZeroRateCurve: all rates must be finite (got $(r))."))
+        all(isfinite, t) || throw(ArgumentError("ZeroRateCurve: all tenors must be finite (got $(t))."))
+        first(t) >= zero(eltype(t)) || throw(ArgumentError("ZeroRateCurve: tenors must be ≥ 0 (got $(t))."))
+        # finiteness is checked first so NaN cannot defeat the ordering comparison
+        for i in 2:length(t)
+            t[i] > t[i - 1] || throw(ArgumentError(
+                "ZeroRateCurve: tenors must be strictly increasing (sorted, no duplicates); got $(t). " *
+                "Sort the (rate, tenor) pairs before constructing."))
+        end
+        k = __min_knots(spline)
+        length(t) >= k || throw(ArgumentError(
+            "ZeroRateCurve: $(spline) requires at least $k knots (got $(length(t)))."))
+        model = Yield.build_model(spline, t, r)   # receives the raw owned Vectors
+        return new{eltype(r), eltype(t), typeof(spline), typeof(model)}(
+            ReadOnlyVector(r), ReadOnlyVector(t), spline, model)
+    end
 end
 
 ZeroRateCurve(rates, tenors) = ZeroRateCurve(rates, tenors, Sp.MonotoneConvex())
 
-function ZeroRateCurve(curve::AbstractYieldModel, tenors; spline=Sp.MonotoneConvex())
-    all(t -> t > zero(t), tenors) || throw(ArgumentError(
+# Sampling form. The grid is normalised ONCE (a stateful iterator must not be consumed
+# twice) and validated BEFORE the source curve is touched (so `Inf` never reaches
+# `discount(curve, Inf)`), then sorted, checked for duplicates, and sampled.
+function ZeroRateCurve(curve::AbstractYieldModel, tenors; spline = Sp.MonotoneConvex())
+    t = sort!(__owned_float_vector(tenors, "tenors"))
+    all(isfinite, t) || throw(ArgumentError("ZeroRateCurve: all tenors must be finite (got $(t))."))
+    first(t) > zero(eltype(t)) || throw(ArgumentError(
         "All tenors must be positive (t > 0). The zero rate is undefined at t = 0."))
-    tenors_f = collect(float.(tenors))
-    rates = [-log(FinanceCore.discount(curve, t)) / t for t in tenors_f]
-    perm = sortperm(tenors_f)
-    return ZeroRateCurve(rates[perm], tenors_f[perm], spline)
+    # same adjacent strict comparison as the inner constructor (`allunique` would treat
+    # Duals with equal primals but different partials as distinct)
+    for i in 2:length(t)
+        t[i] > t[i - 1] || throw(ArgumentError("ZeroRateCurve: tenors must be distinct (got $(t))."))
+    end
+    # Sample through the zero-rate interface rather than `-log(discount)/t`: that round-trip
+    # is numerically unstable at extreme tenors (for a flat 5% curve it gives -0.0 at
+    # t = 1e-20 and Inf at t = 2e4) and would trip the finite-rate validation on curves
+    # that are mathematically fine.
+    rates = [FinanceCore.rate(convert(Continuous(), Base.zero(curve, tᵢ))) for tᵢ in t]
+    return ZeroRateCurve(rates, t, spline)
+end
+
+# Minimum knot counts that the backing interpolants can handle (verified against
+# DataInterpolations 9; `Yield.Spline` already reduces a polynomial/B-spline order to n-1).
+__min_knots(::Sp.SplineCurve) = 2     # Linear / Quadratic / Cubic / BSpline
+__min_knots(::Sp.PCHIP) = 3
+__min_knots(::Sp.Akima) = 3           # 2 knots reach an UndefRefError inside DataInterpolations
+__min_knots(::Sp.MonotoneConvex) = 1  # single knot is a flat curve
+
+# Owned, concretely-typed float `Vector` from any iterable of reals. Always copies (even
+# when handed a `Vector`), so the curve never aliases caller-owned memory; never narrows
+# AD types (`float(::Dual)` is a `Dual`).
+function __owned_float_vector(x, what)
+    v = x isa AbstractVector ? x : collect(x)
+    isempty(v) && throw(ArgumentError("ZeroRateCurve: `$what` must not be empty."))
+    T = isconcretetype(eltype(v)) ? eltype(v) : mapreduce(typeof, promote_type, v)
+    T <: Real || throw(ArgumentError("ZeroRateCurve: `$what` must be real numbers (got element type $T)."))
+    F = try
+        float(T)
+    catch
+        T   # `float(::Type{Real})` etc. has no method; rejected just below
+    end
+    (F <: Real && isconcretetype(F)) || throw(ArgumentError(
+        "ZeroRateCurve: `$what` must promote to one concrete floating-point type (got $F)."))
+    return try
+        Vector{F}(v)   # Array-from-AbstractArray always allocates a fresh copy
+    catch e
+        throw(ArgumentError("ZeroRateCurve: could not convert `$what` to Vector{$F}: $(sprint(showerror, e))"))
+    end
+end
+
+# `_model` is internal: hidden from property access. Internal code uses `getfield`.
+Base.propertynames(::ZeroRateCurve, ::Bool = false) = (:rates, :tenors, :spline)
+function Base.getproperty(z::ZeroRateCurve, s::Symbol)
+    s === :_model && throw(ArgumentError(
+        "ZeroRateCurve: `_model` is internal (derived from rates, tenors and spline) and not accessible; use `discount`/`zero`."))
+    return getfield(z, s)
 end
 
 function FinanceCore.discount(zrc::ZeroRateCurve, t)
@@ -90,15 +192,18 @@ function FinanceCore.discount(zrc::ZeroRateCurve, t)
     # negative times previously returned 1 silently; the curve has no defined
     # behavior before time zero, so error rather than misprice
     t < zero(t) && throw(DomainError(t, "ZeroRateCurve discount is only defined for t ≥ 0"))
-    return discount(zrc._model, t)
+    return discount(getfield(zrc, :_model), t)
 end
 # The callable `zrc(t) ≡ discount(zrc, t)` comes from the generic `AbstractYieldModel` fallback.
 
-# Structural equality on the value-carrying fields. The `_model` field is a
-# deterministic function of (rates, tenors, spline) and may not implement `==`
-# on its underlying interpolation; ignoring it here keeps `a == b` meaningful
-# whenever two curves are built from equal inputs.
+# Structural equality on the value-carrying fields. `_model` is a pure function of
+# `(rates, tenors, spline)` — the storage is owned and read-only and the cache cannot be
+# patched — so ignoring it is sound. `isequal` is defined fieldwise (not via `==`) so that
+# `isequal(a, b)` implies `hash(a) == hash(b)` with Julia's own array semantics
+# (`[-0.0] == [0.0]` but `!isequal([-0.0], [0.0])`).
 Base.:(==)(a::ZeroRateCurve, b::ZeroRateCurve) =
     a.rates == b.rates && a.tenors == b.tenors && a.spline == b.spline
+Base.isequal(a::ZeroRateCurve, b::ZeroRateCurve) =
+    isequal(a.rates, b.rates) && isequal(a.tenors, b.tenors) && isequal(a.spline, b.spline)
 Base.hash(z::ZeroRateCurve, h::UInt) =
     hash(z.rates, hash(z.tenors, hash(z.spline, h)))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -85,3 +85,31 @@ function europut(; S = 1.0, K = 1.0, τ = 1, r, σ, q = 0.0)
     d₂ = d2(S, K, τ, r, σ, q)
     return (N(-d₂) * K - N(-d₁) * S * exp(τ * (r - q))) * exp(-r * τ)
 end
+
+"""
+    ReadOnlyVector(v::Vector)
+
+Internal read-only view over an owned `Vector`. Indexed assignment — and therefore `.=`, `fill!`,
+`sort!`, `reverse!`, and writes through `view` — throws an `ArgumentError`; reads behave as a normal
+`AbstractVector` (indexing, iteration, `searchsortedlast`, broadcasting, `==`/`isequal`/`hash`
+identical to the equivalent `Vector`). The backing storage is a hidden field reachable only via
+`getfield(v, :_data)`; `copy`/`collect` return a mutable `Vector`.
+
+Used by models that cache state derived from their vector fields (`ZeroRateCurve`) so the cache
+can never be desynchronised by mutating the public fields. This is read-only public storage, not
+literal immutability.
+"""
+struct ReadOnlyVector{T} <: AbstractVector{T}
+    _data::Vector{T}
+end
+
+Base.size(v::ReadOnlyVector) = size(getfield(v, :_data))
+Base.IndexStyle(::Type{<:ReadOnlyVector}) = IndexLinear()
+Base.@propagate_inbounds Base.getindex(v::ReadOnlyVector, i::Int) = getfield(v, :_data)[i]
+Base.setindex!(::ReadOnlyVector, _, i...) = throw(ArgumentError(
+    "this vector is read-only: it belongs to a model that caches derived state. " *
+    "Use `Accessors.@set model.field[i] = x` (rebuilds the model) or `copy(v)` for a mutable copy."))
+# Hide the backing storage from ordinary property access (both public and "private" listings).
+Base.propertynames(::ReadOnlyVector, ::Bool = false) = ()
+Base.getproperty(::ReadOnlyVector, s::Symbol) = throw(ArgumentError(
+    "ReadOnlyVector exposes no properties (tried `.$s`); use indexing, `copy`, or `collect`."))

--- a/test/ZeroRateCurve.jl
+++ b/test/ZeroRateCurve.jl
@@ -126,8 +126,8 @@ using ForwardDiff
     end
 
     @testset "eager-build: structural equality preserved" begin
-        # Two ZRCs built from `==`-equal inputs must compare `==` despite the
-        # new `_model` field carrying different prebuilt interpolant instances.
+        # Two ZRCs built from `==`-equal inputs must compare `==` despite their
+        # internal interpolation caches being different prebuilt instances.
         r = [0.02, 0.03, 0.04]; t = [1.0, 2.0, 5.0]
         @test ZeroRateCurve(r, t, Spline.Linear()) == ZeroRateCurve(copy(r), copy(t), Spline.Linear())
         @test hash(ZeroRateCurve(r, t, Spline.Linear())) == hash(ZeroRateCurve(copy(r), copy(t), Spline.Linear()))
@@ -139,5 +139,279 @@ using ForwardDiff
         # same type).
         @test ZeroRateCurve(r, t, Spline.Linear()) != ZeroRateCurve(r, t, Spline.Cubic())
         @test hash(ZeroRateCurve(r, t, Spline.Linear())) != hash(ZeroRateCurve(r, t, Spline.Cubic()))
+    end
+
+    # ─── Owned, read-only storage ─────────────────────────────────────────────
+
+    @testset "read-only storage" begin
+        for spl in (Spline.Linear(), Spline.MonotoneConvex())
+            zrc = ZeroRateCurve([0.02, 0.03, 0.04], [1.0, 2.0, 5.0], spl)
+            df1, h1 = discount(zrc, 1.0), hash(zrc)
+            @test zrc.rates isa AbstractVector{Float64}
+            @test zrc.tenors isa AbstractVector{Float64}
+            # every mutation path must throw
+            @test_throws ArgumentError zrc.rates[1] = 0.2
+            @test_throws ArgumentError zrc.rates .= 0.0
+            @test_throws ArgumentError fill!(zrc.tenors, 1.0)
+            @test_throws ArgumentError reverse!(zrc.tenors)
+            @test_throws ArgumentError sort!(zrc.rates; rev = true)
+            @test_throws ArgumentError view(zrc.rates, 1:2)[1] = 0.2
+            @test_throws ArgumentError view(zrc.rates, :) .= 0.0
+            # hidden backing storage and cache, in both public and private listings
+            @test_throws ArgumentError zrc.rates._data
+            @test propertynames(zrc.rates) == ()
+            @test propertynames(zrc.rates, true) == ()
+            @test propertynames(zrc) == (:rates, :tenors, :spline)
+            @test propertynames(zrc, true) == (:rates, :tenors, :spline)
+            @test_throws ArgumentError zrc._model
+            # nothing above changed the curve
+            @test discount(zrc, 1.0) == df1
+            @test hash(zrc) == h1
+            # read paths behave like a Vector
+            c = copy(zrc.rates)
+            @test c isa Vector{Float64}
+            c[1] = 0.9
+            @test zrc.rates[1] == 0.02
+            @test collect(zrc.tenors) isa Vector{Float64}
+            @test hash(zrc.rates) == hash(collect(zrc.rates))
+            @test isequal(zrc.rates, collect(zrc.rates))
+            @test zrc.rates == [0.02, 0.03, 0.04]
+            @test searchsortedlast(zrc.tenors, 3.0) == 2
+            @test zrc.rates .+ 0.01 isa Vector{Float64}
+            @test collect(zip(zrc.tenors, zrc.rates)) == [(1.0, 0.02), (2.0, 0.03), (5.0, 0.04)]
+        end
+    end
+
+    @testset "caller-input isolation" begin
+        r = [0.02, 0.03, 0.04]; t = [1.0, 2.0, 5.0]
+        for spl in (Spline.Linear(), Spline.MonotoneConvex())
+            zrc = ZeroRateCurve(r, t, spl)
+            ref = ZeroRateCurve(copy(r), copy(t), spl)
+            d = Dict(zrc => :found)
+            r[2] = 0.10; t[2] = 3.0            # mutate the caller's inputs
+            @test discount(zrc, 2.0) ≈ exp(-0.03 * 2.0)
+            @test zrc == ref
+            @test isequal(zrc, ref)
+            @test hash(zrc) == hash(ref)
+            @test d[zrc] == :found
+            @test d[ref] == :found
+            @test zrc != ZeroRateCurve(r, t, spl)
+            r[2] = 0.03; t[2] = 2.0            # restore for the next spline
+        end
+    end
+
+    @testset "signed zero: isequal/hash contract" begin
+        a = ZeroRateCurve([-0.0], [1.0])
+        a′ = ZeroRateCurve([-0.0], [1.0])
+        b = ZeroRateCurve([0.0], [1.0])
+        @test a == b                       # `==` follows array `==` (-0.0 == 0.0)
+        @test !isequal(a, b)               # `isequal` follows array `isequal`
+        @test isequal(a, a′) && hash(a) == hash(a′)
+        d = Dict(a => 1)
+        @test haskey(d, a′)
+        @test !haskey(d, b)                # same behaviour as `Dict([-0.0] => 1)` with key `[0.0]`
+    end
+
+    # ─── Accessors / ConstructionBase ─────────────────────────────────────────
+
+    @testset "ConstructionBase round-trips" begin
+        CB = Accessors.ConstructionBase
+        z = ZeroRateCurve([0.02, 0.03, 0.04], [1.0, 2.0, 5.0], Spline.Linear())
+        @test keys(CB.getproperties(z)) == (:rates, :tenors, :spline)
+        @test CB.setproperties(z, CB.getproperties(z)) == z
+        raw = CB.constructorof(typeof(z))(CB.getfields(z)...)
+        @test raw == z && discount(raw, 3.5) == discount(z, 3.5)
+        @test Accessors.mapproperties(identity, z) == z
+        @test Accessors.getall(z, Accessors.Properties()) == (z.rates, z.tenors, z.spline)
+        newrates = [0.03, 0.04, 0.05]
+        zp = Accessors.setall(z, Accessors.Properties(), (newrates, z.tenors, z.spline))
+        @test zp == ZeroRateCurve(newrates, [1.0, 2.0, 5.0], Spline.Linear())
+        @test discount(zp, 5.0) ≈ exp(-0.05 * 5.0)
+    end
+
+    @testset "Accessors rebuild the cached model" begin
+        CB = Accessors.ConstructionBase
+        r = [0.02, 0.03, 0.04]; t = [1.0, 2.0, 5.0]
+        for spl in (Spline.Linear(), Spline.MonotoneConvex())
+            zrc = ZeroRateCurve(r, t, spl)
+            new = Accessors.@set zrc.rates[2] = 0.05
+            @test new.rates[2] == 0.05
+            @test discount(new, t[2]) ≈ exp(-0.05 * t[2])        # cache rebuilt
+            @test new == ZeroRateCurve([0.02, 0.05, 0.04], t, spl)
+            @test discount(zrc, t[2]) ≈ exp(-0.03 * t[2])        # original untouched
+            @test zrc.rates[2] == 0.03
+        end
+        zrc = ZeroRateCurve(r, t, Spline.MonotoneConvex())
+        # spline swap rebuilds the interpolant
+        lin = Accessors.@set zrc.spline = Spline.Linear()
+        @test lin == ZeroRateCurve(r, t, Spline.Linear())
+        @test discount(lin, 3.5) ≈ discount(ZeroRateCurve(r, t, Spline.Linear()), 3.5)
+        @test discount(lin, 3.5) != discount(zrc, 3.5)
+        # tenor patches: whole-grid replacement and order-preserving single-element updates work
+        g = Accessors.@set zrc.tenors = [1.0, 3.0, 6.0]
+        @test g == ZeroRateCurve(r, [1.0, 3.0, 6.0], Spline.MonotoneConvex())
+        @test discount(g, 6.0) ≈ exp(-0.04 * 6.0)
+        g2 = Accessors.@set zrc.tenors[2] = 1.5
+        @test g2.tenors == [1.0, 1.5, 5.0] && discount(g2, 1.5) ≈ exp(-0.03 * 1.5)
+        # ... but anything that breaks the invariants throws
+        @test_throws ArgumentError Accessors.@set zrc.tenors[2] = 0.5     # breaks ordering
+        @test_throws ArgumentError Accessors.@set zrc.tenors[2] = 5.0     # duplicate
+        @test_throws ArgumentError Accessors.@set zrc.tenors[1] = -1.0    # negative
+        @test_throws ArgumentError Accessors.@set zrc.rates = [NaN, 0.03, 0.04]
+        @test_throws ArgumentError Accessors.@set zrc.rates = [0.02, 0.03]  # length mismatch
+        # the cache cannot be patched (RHS must not read `zrc._model`: that getter throws first)
+        @test_throws ArgumentError zrc._model
+        @test_throws ArgumentError (Accessors.@set zrc._model = nothing)
+        @test_throws ArgumentError CB.setproperties(zrc, (_model = nothing,))
+        @test_throws ArgumentError CB.setproperties(zrc, (foo = 1,))
+        # positional 4-arg reconstruction path (what `setproperties`/`fit` call internally)
+        sp = CB.setproperties(zrc, (rates = [0.03, 0.04, 0.05],))
+        @test sp == ZeroRateCurve([0.03, 0.04, 0.05], t, Spline.MonotoneConvex())
+        @test discount(sp, 5.0) ≈ exp(-0.05 * 5.0)
+        # the cache is retyped when rates become Duals via Accessors
+        dz = Accessors.@set zrc.rates[1] = ForwardDiff.Dual(0.02, 1.0)
+        @test eltype(dz.rates) <: ForwardDiff.Dual
+        @test discount(dz, 1.0) isa ForwardDiff.Dual
+        @test ForwardDiff.partials(discount(dz, 1.0), 1) ≈ -1.0 * exp(-0.02 * 1.0) atol = 1e-12
+        # no public 4-arg constructor
+        @test_throws MethodError ZeroRateCurve(r, t, Spline.Linear(), getfield(zrc, :_model))
+    end
+
+    # ─── Validation ───────────────────────────────────────────────────────────
+
+    @testset "validation" begin
+        @test_throws ArgumentError ZeroRateCurve([0.02, 0.03], [1.0])                  # length mismatch
+        @test_throws ArgumentError ZeroRateCurve(Float64[], Float64[])                 # empty
+        @test_throws ArgumentError ZeroRateCurve([0.02, 0.03], [-1.0, 2.0])            # negative tenor
+        @test_throws ArgumentError ZeroRateCurve([0.02, 0.03], [NaN, 2.0])             # NaN tenor
+        @test_throws ArgumentError ZeroRateCurve([0.02, 0.03], [1.0, Inf])             # Inf tenor
+        @test_throws ArgumentError ZeroRateCurve([NaN, 0.03], [1.0, 2.0])              # NaN rate
+        @test_throws ArgumentError ZeroRateCurve([Inf, 0.03], [1.0, 2.0])              # Inf rate
+        @test_throws ArgumentError ZeroRateCurve([0.02, -Inf], [1.0, 2.0])             # -Inf rate
+        @test_throws ArgumentError ZeroRateCurve(["a"], [1.0])                         # non-numeric
+        @test_throws ArgumentError ZeroRateCurve([0.02], ["1"])                        # non-numeric
+        # duplicate / unsorted tenors are rejected for every interpolant (Linear/PCHIP/Akima
+        # used to accept duplicates silently and produce NaN; MonotoneConvex accepted unsorted)
+        for spl in (Spline.Linear(), Spline.Cubic(), Spline.PCHIP(), Spline.Akima(), Spline.MonotoneConvex())
+            @test_throws ArgumentError ZeroRateCurve([0.02, 0.03, 0.04], [1.0, 1.0, 2.0], spl)
+            @test_throws ArgumentError ZeroRateCurve([0.02, 0.03, 0.04], [2.0, 1.0, 3.0], spl)
+        end
+        # negative rates are valid
+        zneg = ZeroRateCurve([-0.005, 0.01], [1.0, 5.0], Spline.Linear())
+        @test discount(zneg, 1.0) ≈ exp(0.005)
+        # the sampling form takes its spline as a keyword, not positionally
+        @test_throws MethodError ZeroRateCurve(Yield.Constant(0.03), [1.0, 2.0], Spline.Linear())
+        # invalid spline descriptors are rejected at descriptor construction
+        @test_throws ArgumentError Spline.BSpline(-1)
+        @test_throws ArgumentError Spline.BSpline(0)
+        @test_throws ArgumentError Spline.PolynomialSpline(0)
+        @test Spline.BSpline(3).order == 3 && Spline.Cubic().order == 3
+    end
+
+    @testset "element-type promotion" begin
+        z = ZeroRateCurve(Real[0.02f0, 0.03], [1, 2], Spline.Linear())
+        @test eltype(z.rates) === Float64 && eltype(z.tenors) === Float64
+        @test z == ZeroRateCurve([Float64(0.02f0), 0.03], [1.0, 2.0], Spline.Linear())
+        zb = ZeroRateCurve((0.02, 0.03), (1.0f0, big"2"), Spline.Linear())
+        @test eltype(zb.tenors) === BigFloat && eltype(zb.rates) === Float64
+        @test discount(zb, big"1.5") isa BigFloat
+        zd = ZeroRateCurve(Real[0.02, ForwardDiff.Dual(0.03, 1.0)], [1.0, 2.0], Spline.Linear())
+        @test isconcretetype(eltype(zd.rates)) && eltype(zd.rates) <: ForwardDiff.Dual
+        @test isfinite(ForwardDiff.value(discount(zd, 1.5)))
+        zr = ZeroRateCurve((1:3) ./ 100, 1.0:3.0)          # ranges
+        @test zr.rates == [0.01, 0.02, 0.03] && zr.tenors == [1.0, 2.0, 3.0]
+        @test zr.tenors isa AbstractVector{Float64}
+        zi = ZeroRateCurve([0.02, 0.03, 0.04], [1, 2, 5])  # Int tenors
+        @test eltype(zi.tenors) === Float64
+        @test zi == ZeroRateCurve([0.02, 0.03, 0.04], [1.0, 2.0, 5.0])
+        # constructing from another curve's read-only fields copies
+        zc = ZeroRateCurve(zi.rates, zi.tenors, Spline.Linear())
+        @test zc.rates == zi.rates && zc.rates !== zi.rates
+    end
+
+    @testset "minimum knots per interpolant" begin
+        expected = Dict(
+            Spline.Linear() => 2, Spline.Quadratic() => 2, Spline.Cubic() => 2, Spline.BSpline(3) => 2,
+            Spline.PCHIP() => 3, Spline.Akima() => 3, Spline.MonotoneConvex() => 1,
+        )
+        for (spl, k) in expected
+            @test FinanceModels.Yield.__min_knots(spl) == k
+            for T in (Float64, BigFloat)
+                rates = T[0.02 + 0.005 * i for i in 0:(k - 1)]
+                tenors = T[1 + 2i for i in 0:(k - 1)]
+                if k > 1
+                    err = try
+                        ZeroRateCurve(rates[1:(k - 1)], tenors[1:(k - 1)], spl); nothing
+                    catch e
+                        e
+                    end
+                    @test err isa ArgumentError
+                    @test occursin("requires at least $k knots", sprint(showerror, err))
+                end
+                z = ZeroRateCurve(rates, tenors, spl)
+                for τ in (T(0.5), (first(tenors) + last(tenors)) / 2, last(tenors) + 1)
+                    df = discount(z, τ)
+                    @test isfinite(df) && 0 < df <= 1
+                end
+            end
+        end
+        # BigFloat Akima specifically (2 knots used to hit an UndefRefError deep in DataInterpolations)
+        @test_throws ArgumentError ZeroRateCurve(BigFloat[0.02, 0.03], BigFloat[1, 2], Spline.Akima())
+        za = ZeroRateCurve(BigFloat[0.02, 0.03, 0.035], BigFloat[1, 2, 5], Spline.Akima())
+        @test eltype(za.rates) === BigFloat
+        @test isfinite(discount(za, big"1.5"))
+        # a single MonotoneConvex knot is a flat curve
+        z1 = ZeroRateCurve([0.03], [2.0])
+        @test discount(z1, 1.0) ≈ exp(-0.03 * 1.0)
+        @test discount(z1, 4.0) ≈ exp(-0.03 * 4.0)
+    end
+
+    @testset "zero-tenor knot, interior times" begin
+        for spl in (Spline.Linear(), Spline.MonotoneConvex())
+            z0 = ZeroRateCurve([0.02, 0.03], [0.0, 1.0], spl)
+            @test discount(z0, 0.0) == 1.0
+            df = discount(z0, 0.5)
+            @test isfinite(df) && 0 < df < 1
+            @test discount(z0, 1.0) ≈ exp(-0.03)
+            @test isfinite(discount(z0, 2.0))
+        end
+        @test discount(ZeroRateCurve([0.02, 0.03], [0.0, 1.0], Spline.Linear()), 0.5) ≈ exp(-0.025 * 0.5)
+    end
+
+    @testset "sampling form" begin
+        c = Yield.Constant(0.05)
+        # a stateful iterator is normalised exactly once
+        zs = ZeroRateCurve(c, Iterators.Stateful([1.0, 2.0]))
+        @test zs == ZeroRateCurve(c, [1.0, 2.0])
+        @test zs.tenors == [1.0, 2.0]
+        # sampling goes through `zero`, which is stable at extreme tenors
+        # (`-log(discount)/t` gave -0.0 at 1e-20 and Inf at 2e4)
+        ze = ZeroRateCurve(c, [1e-20, 1.0, 2e4])
+        @test all(r -> r ≈ log(1.05), ze.rates)
+        @test_throws ArgumentError ZeroRateCurve(c, [1.0, 1.0])
+        @test_throws ArgumentError ZeroRateCurve(c, Float64[])
+        @test_throws ArgumentError ZeroRateCurve(c, [0.0, 1.0])
+        @test_throws ArgumentError ZeroRateCurve(c, [-1.0, 1.0])
+        # non-finite tenors are rejected before the source curve is ever evaluated
+        touched = Float64[]
+        spy = c + (z, t) -> (push!(touched, t); z)
+        @test_throws ArgumentError ZeroRateCurve(spy, [1.0, Inf])
+        @test isempty(touched)
+        @test_throws ArgumentError ZeroRateCurve(spy, [NaN, 1.0])
+        @test isempty(touched)
+    end
+
+    @testset "generic fit via __default_optic" begin
+        t = [1.0, 2.0, 5.0, 10.0]
+        target = [0.02, 0.025, 0.03, 0.035]
+        qs = ZCBYield.(Continuous.(target), t)        # continuous quotes: fitted zero rates == target
+        zrc0 = ZeroRateCurve(fill(0.01, length(t)), t)
+        @test length(FinanceModels.__default_optic(zrc0)) == length(t)
+        fitted = fit(zrc0, qs)
+        @test fitted isa ZeroRateCurve
+        @test fitted.tenors == t
+        @test maximum(abs, present_value(fitted, q.instrument) - q.price for q in qs) < 1e-6
+        fl = fit(ZeroRateCurve(fill(0.01, length(t)), t, Spline.Linear()), qs)
+        @test fl.rates ≈ target atol = 1e-5
     end
 end


### PR DESCRIPTION
## Problem

`ZeroRateCurve` stored caller-owned mutable `rates`/`tenors` next to a derived, cached interpolation `_model`, and `==`/`hash` compared only `(rates, tenors, spline)`. Consequences:

- Mutating a rates vector (the caller's, or `zrc.rates[1] = …`) left two curves `==` and hash-equal while `discount` differed (DataInterpolations aliases `u`/`t` but keeps stale cached coefficients; MonotoneConvex copies). It also changed the structural hash, making an existing `Dict` key unreachable.
- `Accessors.@set` / `ConstructionBase.setproperties` (i.e. the whole `fit` path) reconstructed through the default positional 4-arg constructor and silently kept the stale `_model`.
- The primary constructor accepted unsorted tenors (silent garbage with MonotoneConvex), duplicate tenors (NaN), length mismatches, empty input, non-finite rates, and too few knots (deep `BoundsError`/`UndefRefError`).
- `isequal` fell back to `==`, so `ZeroRateCurve([-0.0],[1])` and `([0.0],[1])` were `isequal` but hashed differently.

## Change

**Storage (read-only public storage, not literal immutability).** Inputs are copied into owned storage and promoted to one concrete float type (`Int` → `Float64`, `Float32`+`BigFloat` → `BigFloat`, `Float64`+`Dual` → `Dual`; ranges/tuples accepted). `rates`/`tenors` are exposed via a small internal `ReadOnlyVector <: AbstractVector` (`src/utils.jl`): `setindex!`, `.=`, `fill!`, `sort!`, `reverse!`, and writes through `view` throw; the backing field and `_model` are hidden from `getproperty`/`propertynames`. Reads, `searchsortedlast`, `zip`, broadcasting, `copy`/`collect` behave as before — ActuaryUtilities and `examples/` keep working unchanged.

**One validated inner constructor.** `ArgumentError` on length mismatch, empty input, non-finite rates/tenors, negative tenors, not-strictly-increasing tenors, and fewer knots than the interpolant supports (PCHIP/Akima 3; Linear/Quadratic/Cubic/BSpline 2; MonotoneConvex 1 — verified against DataInterpolations 9.3). No 4-arg constructor exists. `Spline.BSpline(d)`/`PolynomialSpline(d)` now require `d ≥ 1`.

**ConstructionBase / Accessors.** `getproperties` returns `(rates, tenors, spline)`; `setproperties` re-validates and rebuilds through the constructor and rejects `_model`/unknown keys; a raw `constructorof` closure satisfies `constructorof(T)(getfields(z)...) == z`. So `@set zrc.rates[i] = x`, `@set zrc.tenors = grid`, `@set zrc.spline = …`, `mapproperties`, `Properties()` optics and `fit` all rebuild the cache — it can never go stale. Adds `__default_optic(::ZeroRateCurve)` so `fit(zrc, quotes)` works (mirrors `MonotoneConvex`).

**Equality.** Fieldwise `isequal`; `hash` unchanged → `isequal ⇒ hash` holds with Julia's array semantics.

**Sampling form** (`ZeroRateCurve(curve, tenors)`) normalises its grid once (stateful iterators are safe), validates before evaluating the source curve, still sorts and requires `t > 0`, and samples through `zero(curve, t)` instead of `-log(discount)/t` (which gave `-0.0` at `t=1e-20` and `Inf` at `t=2e4` for a flat 5% curve).

## Tests

`test/ZeroRateCurve.jl` gains testsets for read-only storage and hidden fields (incl. `propertynames(x, true)` and writes through `view`), caller-input isolation + `Dict` reachability, the signed-zero `isequal`/`hash` contract, ConstructionBase round-trips (`setproperties∘getproperties`, `constructorof∘getfields`, `mapproperties`, `Properties()`), Accessors rebuilds (rates/tenors/spline, invalid patches, `_model` rejection, Dual retyping), validation, promotion (`Float32`/`BigFloat`/`Dual`/`Int`/ranges/tuples), per-interpolant minimum knots for `Float64` and `BigFloat` (incl. BigFloat Akima), `t = 0` knots at interior times, the sampling form (stateful iterator, extreme tenors, `Inf` rejected before `discount` is called), and `fit` round-trips. All existing tests pass unchanged.

- `Pkg.test()` — full suite incl. Aqua: passes (DataInterpolations 9.3.0).
- Full **ActuaryUtilities** test suite run against this branch: passes (34 testsets, incl. its `ZeroRateCurve` duration/sensitivities/external-validation groups).

## Migration

Documented in `docs/src/migration.md` under "v6.4 to v6.5". No version bump in this PR (release commit to follow: 6.5.0).

## Follow-ups (not in this PR)

- `Yield.ForwardStarting` has the same latent `@set` cache bug (cached `discount_to_forwardstart`, no `constructorof`).
- `zero(zrc, 0)` is `NaN` via the generic `-log(DF)/t` fallback (pre-existing); delegating `zero` to the cached model would give the finite limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
