### PR TITLE
Preserve numeric types in cashflow matrices

### DIFF
--- a/src/Contract.jl
+++ b/src/Contract.jl
@@ -556,7 +556,9 @@ function cashflows_timepoints(qs)
         map(c -> c.time, cf)
     end |> Iterators.flatten |> unique |> sort!
 
-    m = zeros(length(times), length(qs))
+    amounts = [cf.amount for contract_cashflows in cfs for cf in contract_cashflows]
+    amount_type = isempty(amounts) ? Float64 : promote_type(typeof.(amounts)...)
+    m = zeros(amount_type, length(times), length(qs))
 
     for t in 1:length(times)
         for q in 1:length(qs)

--- a/src/Contract.jl
+++ b/src/Contract.jl
@@ -557,7 +557,7 @@ function cashflows_timepoints(qs)
     end |> Iterators.flatten |> unique |> sort!
 
     amounts = [cf.amount for contract_cashflows in cfs for cf in contract_cashflows]
-    amount_type = isempty(amounts) ? Float64 : promote_type(typeof.(amounts)...)
+    amount_type = isempty(amounts) ? Float64 : mapreduce(typeof, promote_type, amounts)
     m = zeros(amount_type, length(times), length(qs))
 
     for t in 1:length(times)

--- a/test/SmithWilson.jl
+++ b/test/SmithWilson.jl
@@ -1,3 +1,5 @@
+using ForwardDiff
+
 @testset "SmithWilson" begin
 
     ufr = 0.03
@@ -77,6 +79,12 @@
 
     sw_swq = fit(Yield.SmithWilson(ufr = ufr, α = α), qs)
     swq_payments, swq_times = FinanceModels.cashflows_timepoints(qs)
+    big_payments, _ = FinanceModels.cashflows_timepoints([Cashflow(big"1.000000000000000000000000000001", 1.0)])
+    @test eltype(big_payments) == BigFloat
+    @test big_payments[1] == big"1.000000000000000000000000000001"
+    dual_amount = ForwardDiff.Dual(1.0, 1.0)
+    dual_payments, _ = FinanceModels.cashflows_timepoints([Cashflow(dual_amount, 1.0)])
+    @test dual_payments[1] == dual_amount
     @testset "SwapQuotes round-trip" for swapIdx in 1:length(coupon)
         @test sum(discount.(sw_swq, swq_times) .* swq_payments[:, swapIdx]) ≈ 1.0
     end


### PR DESCRIPTION
## Summary\n- infer the cashflow matrix element type from all cashflow amounts\n- retain the existing Float64 fallback only for collections with no amounts\n- preserve BigFloat precision and accept AD dual values\n\n## Tests\n- exact high-precision BigFloat amount regression\n- ForwardDiff dual-number regression