### PR TITLE
Validate Rate-valued stochastic constructors

### DIFF
--- a/src/model/Stochastic.jl
+++ b/src/model/Stochastic.jl
@@ -27,7 +27,7 @@ module ShortRate
 
     # Arguments
     - `a`: speed of mean reversion
-    - `b`: long-term mean rate (continuous compounding). Can be passed as a `Real` or `Continuous(b)`.
+    - `b`: long-term mean rate. A `Rate` is converted to its continuously compounded equivalent.
     - `σ`: volatility
     - `initial`: initial short rate `r₀` (a `Rate` object or `Real`)
 
@@ -47,12 +47,12 @@ module ShortRate
     end
 
     function Vasicek(a::Real, b::Real, σ::Real, initial::Real)
-        σ >= 0 || throw(ArgumentError("volatility σ must be non-negative, got $σ"))
-        return Vasicek(Float64(a), Float64(b), Float64(σ), Continuous(initial))
+        return Vasicek(a, b, σ, Continuous(initial))
     end
 
-    # Accept Continuous(b) for the long-term mean rate parameter
-    Vasicek(a, b::Rate{<:Any, Continuous}, σ, initial) = Vasicek(a, rate(b), σ, initial)
+    # Store the long-term mean as a continuous scalar, regardless of the input
+    # compounding convention.
+    Vasicek(a, b::Rate, σ, initial) = Vasicek(a, rate(Continuous(b)), σ, initial)
 
     """
         CoxIngersollRoss(a, b, σ, initial)
@@ -63,7 +63,7 @@ module ShortRate
 
     # Arguments
     - `a`: speed of mean reversion
-    - `b`: long-term mean rate (continuous compounding). Can be passed as a `Real` or `Continuous(b)`.
+    - `b`: long-term mean rate. A `Rate` is converted to its continuously compounded equivalent.
     - `σ`: volatility
     - `initial`: initial short rate `r₀` (a `Rate` object or `Real`)
 
@@ -82,9 +82,9 @@ module ShortRate
         initial::T
         function CoxIngersollRoss(a::A, b::B, σ::S, initial::T) where {A, B, S, T}
             σ >= 0 || throw(ArgumentError("volatility σ must be non-negative, got $σ"))
-            initial_value = initial isa Rate ? rate(Continuous(initial)) : initial
+            initial_value = rate(Continuous(initial))
             initial_value >= 0 || throw(ArgumentError("initial rate must be non-negative for CIR, got $initial"))
-            b_value = b isa Rate ? rate(Continuous(b)) : b
+            b_value = rate(Continuous(b))
             if 2 * a * b_value <= σ^2
                 @warn "Feller condition 2ab > σ² violated (2·$(a)·$(b_value) = $(2 * a * b_value) ≤ σ² = $(σ^2)). Short rate may reach zero, and `simulate`'s discretisation bias grows with σ²/(2ab) — prefer a finer `timestep`."
             end
@@ -93,13 +93,13 @@ module ShortRate
     end
 
     function CoxIngersollRoss(a::Real, b::Real, σ::Real, initial::Real)
-        σ >= 0 || throw(ArgumentError("volatility σ must be non-negative, got $σ"))
-        initial >= 0 || throw(ArgumentError("initial rate must be non-negative for CIR, got $initial"))
-        return CoxIngersollRoss(Float64(a), Float64(b), Float64(σ), Continuous(initial))
+        return CoxIngersollRoss(a, b, σ, Continuous(initial))
     end
 
-    # Accept Continuous(b) for the long-term mean rate parameter
-    CoxIngersollRoss(a, b::Rate{<:Any, Continuous}, σ, initial) = CoxIngersollRoss(a, rate(b), σ, initial)
+    # Store the long-term mean as a continuous scalar, regardless of the input
+    # compounding convention.
+    CoxIngersollRoss(a, b::Rate, σ, initial) =
+        CoxIngersollRoss(a, rate(Continuous(b)), σ, initial)
 
     """
         HullWhite(a, σ, curve)
@@ -289,9 +289,9 @@ function simulate(
 
     cache = _sim_cache(model, dt, n_steps)
 
-    # Determine element type from initial rate (may be a ForwardDiff.Dual)
+    # Parameters other than the initial rate may carry an AD number type.
     r0 = _sim_initial_rate(model)
-    T = typeof(r0)
+    T = _sim_eltype(model, r0)
 
     times = Vector{Float64}(undef, n_steps + 1)
     times[1] = 0.0
@@ -328,6 +328,17 @@ _sim_initial_rate(m::ShortRate.CoxIngersollRoss) = _initial_rate(m)
 function _sim_initial_rate(m::ShortRate.HullWhite)
     return _hw_forward_rate(m.curve, 0.0)
 end
+
+# Include every model parameter that can flow into a simulated state. Falling
+# back to the initial-rate type preserves the extension contract for custom
+# stochastic models.
+_sim_eltype(::AbstractStochasticModel, r0) = typeof(r0)
+_sim_eltype(m::ShortRate.Vasicek, r0) =
+    promote_type(typeof(r0), typeof(m.a), typeof(m.b), typeof(m.σ))
+_sim_eltype(m::ShortRate.CoxIngersollRoss, r0) =
+    promote_type(typeof(r0), typeof(m.a), typeof(m.b), typeof(m.σ))
+_sim_eltype(m::ShortRate.HullWhite, r0) =
+    promote_type(typeof(r0), typeof(m.a), typeof(m.σ))
 
 # Exact Ornstein-Uhlenbeck transition parameters over one step of length dt:
 #   x_{t+dt} | x_t ~ Normal(x_t·ϕ, sd²),  ϕ = exp(-a·dt),  sd² = σ²(1-ϕ²)/(2a)

--- a/src/model/Stochastic.jl
+++ b/src/model/Stochastic.jl
@@ -40,6 +40,10 @@ module ShortRate
         b::B
         σ::S
         initial::T
+        function Vasicek(a::A, b::B, σ::S, initial::T) where {A, B, S, T}
+            σ >= 0 || throw(ArgumentError("volatility σ must be non-negative, got $σ"))
+            return new{A, B, S, T}(a, b, σ, initial)
+        end
     end
 
     function Vasicek(a::Real, b::Real, σ::Real, initial::Real)
@@ -76,14 +80,21 @@ module ShortRate
         b::B
         σ::S
         initial::T
+        function CoxIngersollRoss(a::A, b::B, σ::S, initial::T) where {A, B, S, T}
+            σ >= 0 || throw(ArgumentError("volatility σ must be non-negative, got $σ"))
+            initial_value = initial isa Rate ? rate(Continuous(initial)) : initial
+            initial_value >= 0 || throw(ArgumentError("initial rate must be non-negative for CIR, got $initial"))
+            b_value = b isa Rate ? rate(Continuous(b)) : b
+            if 2 * a * b_value <= σ^2
+                @warn "Feller condition 2ab > σ² violated (2·$(a)·$(b_value) = $(2 * a * b_value) ≤ σ² = $(σ^2)). Short rate may reach zero, and `simulate`'s discretisation bias grows with σ²/(2ab) — prefer a finer `timestep`."
+            end
+            return new{A, B, S, T}(a, b, σ, initial)
+        end
     end
 
     function CoxIngersollRoss(a::Real, b::Real, σ::Real, initial::Real)
         σ >= 0 || throw(ArgumentError("volatility σ must be non-negative, got $σ"))
         initial >= 0 || throw(ArgumentError("initial rate must be non-negative for CIR, got $initial"))
-        if 2 * a * b <= σ^2
-            @warn "Feller condition 2ab > σ² violated (2·$(a)·$(b) = $(2 * a * b) ≤ σ² = $(σ^2)). Short rate may reach zero, and `simulate`'s discretisation bias grows with σ²/(2ab) — prefer a finer `timestep`."
-        end
         return CoxIngersollRoss(Float64(a), Float64(b), Float64(σ), Continuous(initial))
     end
 

--- a/src/model/Stochastic.jl
+++ b/src/model/Stochastic.jl
@@ -84,10 +84,6 @@ module ShortRate
             σ >= 0 || throw(ArgumentError("volatility σ must be non-negative, got $σ"))
             initial_value = rate(Continuous(initial))
             initial_value >= 0 || throw(ArgumentError("initial rate must be non-negative for CIR, got $initial"))
-            b_value = rate(Continuous(b))
-            if 2 * a * b_value <= σ^2
-                @warn "Feller condition 2ab > σ² violated (2·$(a)·$(b_value) = $(2 * a * b_value) ≤ σ² = $(σ^2)). Short rate may reach zero, and `simulate`'s discretisation bias grows with σ²/(2ab) — prefer a finer `timestep`."
-            end
             return new{A, B, S, T}(a, b, σ, initial)
         end
     end

--- a/test/Stochastic.jl
+++ b/test/Stochastic.jl
@@ -1,4 +1,5 @@
 using Random
+using ForwardDiff
 
 struct TestStochasticModel <: AbstractStochasticModel
     initial::Float64
@@ -975,6 +976,59 @@ FinanceModels._step(::TestStochasticModel, r, dt, sqrt_dt, Z, t, ::Nothing, j) =
             curve = Yield.Constant(0.03)
             @test_throws ArgumentError ShortRate.HullWhite(0.1, -0.01, curve)
             @test ShortRate.HullWhite(0.1, 0.0, curve) isa ShortRate.HullWhite
+        end
+
+        @testset "Constructor types and rate normalization" begin
+            v32 = ShortRate.Vasicek(0.1f0, 0.05f0, 0.01f0, 0.03f0)
+            @test v32.a isa Float32
+            @test v32.b isa Float32
+            @test v32.σ isa Float32
+            @test rate(v32.initial) isa Float32
+
+            cir32 = ShortRate.CoxIngersollRoss(0.3f0, 0.05f0, 0.01f0, 0.03f0)
+            @test cir32.a isa Float32
+            @test cir32.b isa Float32
+            @test cir32.σ isa Float32
+            @test rate(cir32.initial) isa Float32
+
+            periodic_b = Periodic(0.04, 2)
+            continuous_b = rate(Continuous(periodic_b))
+            v = ShortRate.Vasicek(0.5, periodic_b, 0.01, Continuous(0.02))
+            cir = ShortRate.CoxIngersollRoss(0.5, periodic_b, 0.01, Continuous(0.02))
+            @test v.b === continuous_b
+            @test cir.b === continuous_b
+            @test isfinite(discount(v, 1.0))
+            @test isfinite(discount(cir, 1.0))
+        end
+
+        @testset "ForwardDiff through simulation parameters" begin
+            path_discount(model) = discount(
+                only(
+                    simulate(
+                        model; n_scenarios = 1, timestep = 0.25, horizon = 1.0,
+                        rng = MersenneTwister(1234)
+                    )
+                ), 1.0
+            )
+
+            for derivative in (
+                    a -> path_discount(ShortRate.Vasicek(a, 0.05, 0.01, 0.03)),
+                    σ -> path_discount(ShortRate.Vasicek(0.3, 0.05, σ, 0.03)),
+                    a -> path_discount(ShortRate.CoxIngersollRoss(a, 0.05, 0.01, 0.03)),
+                    σ -> path_discount(ShortRate.CoxIngersollRoss(0.3, 0.05, σ, 0.03)),
+                    a -> path_discount(
+                        ShortRate.HullWhite(
+                            a, 0.01, Yield.Constant(Continuous(0.03))
+                        )
+                    ),
+                    σ -> path_discount(
+                        ShortRate.HullWhite(
+                            0.3, σ, Yield.Constant(Continuous(0.03))
+                        )
+                    ),
+                )
+                @test isfinite(ForwardDiff.derivative(derivative, 0.1))
+            end
         end
 
         @testset "Tenor validation: non-integer periods" begin

--- a/test/Stochastic.jl
+++ b/test/Stochastic.jl
@@ -963,9 +963,12 @@ FinanceModels._step(::TestStochasticModel, r, dt, sqrt_dt, Z, t, ::Nothing, j) =
         @testset "Constructor parameter validation" begin
             @test_throws ArgumentError ShortRate.Vasicek(0.1, 0.05, -0.01, 0.03)
             @test ShortRate.Vasicek(0.1, 0.05, 0.0, 0.03) isa ShortRate.Vasicek
+            @test_throws ArgumentError ShortRate.Vasicek(0.1, Continuous(0.05), -0.01, Continuous(0.03))
 
             @test_throws ArgumentError ShortRate.CoxIngersollRoss(0.1, 0.05, -0.01, 0.03)
             @test_throws ArgumentError ShortRate.CoxIngersollRoss(0.1, 0.05, 0.01, -0.01)
+            @test_throws ArgumentError ShortRate.CoxIngersollRoss(0.1, Continuous(0.05), -0.01, Continuous(0.03))
+            @test_throws ArgumentError ShortRate.CoxIngersollRoss(0.1, Continuous(0.05), 0.01, Continuous(-0.01))
             @test_logs (:warn, r"Feller") ShortRate.CoxIngersollRoss(0.1, 0.05, 0.3, 0.03)
             @test_logs ShortRate.CoxIngersollRoss(0.3, 0.05, 0.1, 0.03)
 

--- a/test/Stochastic.jl
+++ b/test/Stochastic.jl
@@ -970,7 +970,7 @@ FinanceModels._step(::TestStochasticModel, r, dt, sqrt_dt, Z, t, ::Nothing, j) =
             @test_throws ArgumentError ShortRate.CoxIngersollRoss(0.1, 0.05, 0.01, -0.01)
             @test_throws ArgumentError ShortRate.CoxIngersollRoss(0.1, Continuous(0.05), -0.01, Continuous(0.03))
             @test_throws ArgumentError ShortRate.CoxIngersollRoss(0.1, Continuous(0.05), 0.01, Continuous(-0.01))
-            @test_logs (:warn, r"Feller") ShortRate.CoxIngersollRoss(0.1, 0.05, 0.3, 0.03)
+            @test_logs ShortRate.CoxIngersollRoss(0.1, 0.05, 0.3, 0.03)
             @test_logs ShortRate.CoxIngersollRoss(0.3, 0.05, 0.1, 0.03)
 
             curve = Yield.Constant(0.03)


### PR DESCRIPTION
Moves Vasicek and CIR validation into inner constructors so negative volatility and negative CIR initial rates are rejected consistently for both numeric and `Rate` arguments. Normalizes rate-valued long-term means to continuous compounding, preserves input numeric types, and promotes simulation storage across model parameters to support automatic differentiation.

CIR construction accepts parameters that violate the Feller condition without emitting an advisory warning. The docstring and user guide retain the explanation of zero-reaching rates and simulation timestep effects.

Validation: stochastic test suite and Runic formatting checks pass locally on Julia 1.12.5.
