### PR TITLE
Reject Monte Carlo horizons before contract maturity

### DIFF
--- a/src/model/Stochastic.jl
+++ b/src/model/Stochastic.jl
@@ -391,14 +391,17 @@ by averaging `present_value` across simulated scenarios.
     provides the discount factors. For floating-rate instruments whose cashflows depend
     on the rate path, project cashflows per scenario using `Projection` instead.
 
-The `horizon` should cover the contract's maturity. The default (`maturity + 1`) ensures this.
+The `horizon` must cover the contract's maturity. The default (`maturity + 1`) ensures this;
+an explicitly shorter horizon throws an `ArgumentError` rather than extrapolating the path.
 """
 function pv_mc(model::AbstractStochasticModel, contract;
                n_scenarios::Int = 1000,
                timestep::Real = 1 / 12,
                horizon::Union{Nothing,Real} = nothing,
                rng::Random.AbstractRNG = Random.default_rng())
-    h = horizon === nothing ? Float64(FinanceModels.maturity(contract)) + 1.0 : Float64(horizon)
+    contract_maturity = Float64(FinanceModels.maturity(contract))
+    h = horizon === nothing ? contract_maturity + 1.0 : Float64(horizon)
+    h >= contract_maturity || throw(ArgumentError("simulation horizon $h is shorter than contract maturity $contract_maturity"))
     scenarios = simulate(model; n_scenarios, timestep, horizon = h, rng)
     total = sum(FinanceCore.present_value(sc, contract) for sc in scenarios)
     return total / n_scenarios

--- a/test/Stochastic.jl
+++ b/test/Stochastic.jl
@@ -952,6 +952,13 @@ FinanceModels._step(::TestStochasticModel, r, dt, sqrt_dt, Z, t, ::Nothing, j) =
             @test_throws ArgumentError simulate(v; timestep = -0.1)
         end
 
+        @testset "pv_mc: horizon covers maturity" begin
+            v = ShortRate.Vasicek(0.1, 0.05, 0.0, 0.03)
+            contract = Cashflow(1.0, 10.0)
+            @test_throws ArgumentError pv_mc(v, contract; horizon = 1.0, n_scenarios = 1)
+            @test pv_mc(v, contract; horizon = 10.0, n_scenarios = 1) isa Real
+        end
+
         @testset "ZCB option: strike must be positive" begin
             hw = ShortRate.HullWhite(0.1, 0.01, Yield.Constant(Continuous(0.05)))
             @test_throws ArgumentError present_value(hw, Option.ZCBCall(1.0, 5.0, 0.0))


### PR DESCRIPTION
Requires an explicit pv_mc horizon to cover contract maturity and throws ArgumentError instead of silently extrapolating RatePath. Documents the policy and tests rejection for a ten-year cashflow simulated only through year one.