### PR TITLE
Stabilize CIR prices at long horizons

### DIFF
--- a/src/model/Stochastic.jl
+++ b/src/model/Stochastic.jl
@@ -161,10 +161,13 @@ function _cir_zcb(a, b, σ, r, τ)
         end
     end
     γ = sqrt(a^2 + 2σ^2)
-    expγτ = exp(γ * τ)
-    denom = (γ + a) * (expγτ - 1) + 2γ
-    B = 2(expγτ - 1) / denom
-    A = (2γ * exp((a + γ) * τ / 2) / denom)^(2a * b / σ^2)
+    # Divide the standard formula through by exp(γτ). This avoids forming
+    # exp(γτ) directly, which overflows for valid long maturities.
+    one_minus_exp_neg = -expm1(-γ * τ)
+    exp_neg = exp(-γ * τ)
+    scaled_denom = (γ + a) * one_minus_exp_neg + 2γ * exp_neg
+    B = 2one_minus_exp_neg / scaled_denom
+    A = (2γ * exp((a - γ) * τ / 2) / scaled_denom)^(2a * b / σ^2)
     return A * exp(-B * r)
 end
 

--- a/test/Stochastic.jl
+++ b/test/Stochastic.jl
@@ -972,6 +972,13 @@ FinanceModels._step(::TestStochasticModel, r, dt, sqrt_dt, Z, t, ::Nothing, j) =
             @test ShortRate.HullWhite(0.1, 0.0, curve) isa ShortRate.HullWhite
         end
 
+
+        @testset "CIR long-horizon discount stability" begin
+            cir = ShortRate.CoxIngersollRoss(0.3, 0.05, 0.1, 0.03)
+            @test isfinite(discount(cir, 10_000.0))
+            @test 0.0 <= discount(cir, 10_000.0) <= 1.0
+        end
+
         @testset "Tenor validation: non-integer periods" begin
             hw = ShortRate.HullWhite(0.1, 0.01, Yield.Constant(Continuous(0.05)))
             # Cap maturity 1.3 with quarterly freq → 1.3 * 4 = 5.2, not integer


### PR DESCRIPTION
Algebraically scales the CIR bond formula by the negative exponential, avoiding direct formation of the overflowing positive exponential. Existing analytical regressions pass and a valid 10,000-year input remains finite. Full suite passes locally.