### PR TITLE
Complete maturity behavior for options and forwards

### DIFF
--- a/src/Contract.jl
+++ b/src/Contract.jl
@@ -398,7 +398,7 @@ A European call option on the given contract with the given strike and maturity.
 # Arguments
  - contract::AbstractContract -  The underlying contract.
  - strike::Real -  The strike price.
- - maturity::Union{Real,Date} -  The maturity of the option.
+ - maturity::Real -  Time to maturity in years.
 
  Supertype Hierarchy
 ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -406,7 +406,7 @@ A European call option on the given contract with the given strike and maturity.
     EuroCall{S,K,M} <: FinanceCore.AbstractContract <: Any
 
 """
-struct EuroCall{S <: AbstractContract, K <: Real, M <: Timepoint} <: AbstractContract
+struct EuroCall{S <: AbstractContract, K <: Real, M <: Real} <: AbstractContract
     underlying::S
     strike::K
     maturity::M
@@ -420,7 +420,7 @@ A European put option on the given contract with the given strike and maturity.
 # Arguments
  - contract::AbstractContract -  The underlying contract.
  - strike::Real -  The strike price.
- - maturity::Union{Real,Date} -  The maturity of the option.
+ - maturity::Real -  Time to maturity in years.
 
  Supertype Hierarchy
 ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
@@ -428,7 +428,7 @@ A European put option on the given contract with the given strike and maturity.
     EuroPut{S,K,M} <: FinanceCore.AbstractContract <: Any
 
 """
-struct EuroPut{S <: AbstractContract, K <: Real, M <: Timepoint} <: AbstractContract
+struct EuroPut{S <: AbstractContract, K <: Real, M <: Real} <: AbstractContract
     underlying::S
     strike::K
     maturity::M
@@ -510,6 +510,8 @@ function Swaption(expiry, swap_maturity, strike, frequency; payer = true)
 end
 
 import ..FinanceCore: maturity
+maturity(c::EuroCall) = c.maturity
+maturity(c::EuroPut) = c.maturity
 maturity(c::ZCBCall) = c.bond_maturity
 maturity(c::ZCBPut) = c.bond_maturity
 maturity(c::Cap) = c.maturity
@@ -521,13 +523,17 @@ end
 """
 Forward(time,instrument)
 
-The instrument is relative to the Forward time.
+The instrument is relative to the Forward time. `time` and the instrument's
+timepoints are year fractions; calendar dates require an explicit valuation
+date and day-count conversion before construction.
 e.g. if you have a `Forward(1.0, Cashflow(1.0, 3.0))` then the instrument is a cashflow that pays 1.0 at time 4.0
 """
-struct Forward{T <: FinanceCore.Timepoint, I <: FinanceCore.AbstractContract} <: FinanceCore.AbstractContract
+struct Forward{T <: Real, I <: FinanceCore.AbstractContract} <: FinanceCore.AbstractContract
     time::T
     instrument::I
 end
+
+FinanceCore.maturity(c::Forward) = c.time + FinanceCore.maturity(c.instrument)
 
 
 """

--- a/test/Equity.jl
+++ b/test/Equity.jl
@@ -1,3 +1,5 @@
+using Dates
+
 @testset "Derivatives" begin
 
     @testset "Euro Options" begin
@@ -40,6 +42,10 @@ end
     @test pv(m, a) ≈ 0.05410094201902403
 
     ap = Option.EuroPut(CommonEquity(), 1.0, 1.0)
+    @test maturity(a) == 1.0
+    @test maturity(ap) == 1.0
+    @test_throws MethodError Option.EuroCall(CommonEquity(), 1.0, Date(2030, 1, 1))
+    @test_throws MethodError Option.EuroPut(CommonEquity(), 1.0, Date(2030, 1, 1))
 
     # put call parity with continuous dividend yield
     # https://web.ma.utexas.edu/users/mcudina/m339d_lecture6.pdf, pg 2

--- a/test/regressions.jl
+++ b/test/regressions.jl
@@ -1,3 +1,5 @@
+using Dates
+
 # Regression tests from the 2026-06 ecosystem audit
 @testset "audit regressions" begin
     @testset "fit(spline, quotes, Fit.Loss) uses the supplied loss" begin
@@ -31,6 +33,8 @@
     @testset "Forward contract shifts cashflow times" begin
         b = Bond.Fixed(0.05, Periodic(1), 2)
         fwd = Forward(1.0, b)
+        @test maturity(fwd) == 3.0
+        @test_throws MethodError Forward(Date(2030, 1, 1), b)
         cfs = collect(Projection(fwd, NullModel(), CashflowProjection()))
         @test [cf.time for cf in cfs] ≈ [2.0, 3.0]
         @test [cf.amount for cf in cfs] ≈ [0.05, 1.05]


### PR DESCRIPTION
Implements maturity for EuroCall and EuroPut and defines generic Forward maturity as forward start plus underlying maturity. Requires year-fraction Real timepoints and rejects Date inputs that lack valuation-date and day-count context. Includes direct maturity and Date rejection tests.