### PR TITLE
Add a named zero_rate API

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -115,7 +115,7 @@ The models can be used to compute various rates of interest:
 
 - `discount(curve,from,to)` or `discount(curve,to)` gives the discount factor
 - `accumulation(curve,from,to)` or `accumulation(curve,to)` gives the accumulation factor
-- `zero(curve,time)` gives the zero-coupon spot rate for the given time (returned as a `Continuous` `Rate`).
+- `zero_rate(curve,time)` gives the zero-coupon spot rate for the given time (returned as a `Continuous` `Rate`). `zero(curve,time)` remains available for compatibility, but the named API avoids repurposing `Base.zero` and is the recommended spelling for new code.
 - `forward(curve,from,to)` gives the zero rate between the two given times
 - `par(curve,time;frequency=2)` gives the coupon-paying par equivalent rate for the given time.
 

--- a/src/FinanceModels.jl
+++ b/src/FinanceModels.jl
@@ -31,7 +31,9 @@ export Bond, ZCBYield, ZCBPrice, ParSwapYield, ParYield, CMTYield, ForwardYield,
 
 export Spline
 
-export NullModel, Yield, discount, accumulation, zero, forward
+export NullModel, Yield, discount, accumulation, zero, zero_rate, forward
+
+using .Yield: zero_rate
 
 using .Yield: ZeroRateCurve
 export ZeroRateCurve

--- a/src/model/Yield.jl
+++ b/src/model/Yield.jl
@@ -7,7 +7,7 @@ import ..Bond: coupon_times, __regular_schedule, __par_coupon
 
 using ..FinanceCore: Continuous, Periodic, discount, accumulation, forward, pv, AbstractContract
 
-export discount, zero, forward, par, pv, instantaneous_forward
+export discount, zero, zero_rate, forward, par, pv, instantaneous_forward
 
 abstract type AbstractYieldModel <: AbstractModel end
 
@@ -234,6 +234,18 @@ function Base.zero(c::YC, time) where {YC <: AbstractYieldModel}
     r = -log(df) / time
     return Continuous(r)
 end
+
+"""
+    zero_rate(curve, time)
+
+Return the continuously compounded zero-coupon rate for `curve` at `time`.
+
+This named financial operation is preferred over `Base.zero(curve, time)`, which
+is retained for compatibility. A future major release may make `zero_rate` the
+primary extension point so `Base.zero` can recover its usual additive-identity
+meaning.
+"""
+zero_rate(c::AbstractYieldModel, time) = Base.zero(c, time)
 
 """
     accumulation(yc, from, to)

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -10,6 +10,7 @@
 
     my = MyYield(0.05)
     @test zero(my, 1) ≈ Continuous(0.05)
+    @test zero_rate(my, 1) ≈ Continuous(0.05)
     @test forward(my, 1) ≈ Continuous(0.05)
     @test forward(my, 1, 2) ≈ Continuous(0.05)
     @test discount(my, 1, 2) ≈ exp(-0.05 * 1)


### PR DESCRIPTION
Exports zero_rate(curve, time) as the preferred financial operation while retaining Base.zero compatibility. Documents the additive migration path so a future major release can restore the usual Base.zero meaning. Existing third-party implementations continue to work.