### PR TITLE
Clarify Cairns–Pritchard provenance and tidy documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 Manifest.toml
 .DS_Store
 .claude/
+
+# Local review and planning notes
+/notes/

--- a/src/Contract.jl
+++ b/src/Contract.jl
@@ -236,7 +236,7 @@ module Bond
     end
 
     """
-    OISYield(yield, maturity)
+        OISYield(yield, maturity)
 
     Returns the implied `Quote` for the fixed bond implied by the given `yield` and `maturity`. Assumes that maturities less than or equal to 12 months are settled once (per Hull textbook, 4.7), otherwise quarterly and that the FinanceModels given are bond equivalent.
 
@@ -384,7 +384,10 @@ See also: [`Option`](@ref).
 struct CommonEquity <: FinanceCore.AbstractContract end
 
 """
+Option contracts, including European calls and puts on underlying contracts,
+zero-coupon bond options, caps, and floors.
 
+See [`Option.EuroCall`](@ref) and [`Option.EuroPut`](@ref).
 """
 module Option
     import ..FinanceCore: AbstractContract, Timepoint

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -29,11 +29,18 @@ module Fit
     """
         Bootstrap()
 
-    A singleton type which is passed to `fit` in order to bootstrap Splines. The curves are fit such that the spline passes through the zero rates of the curve. 
+    A singleton type passed to `fit` to bootstrap a spline curve one quote at a time.
+    Each step solves for the zero rate at the next quote maturity to match its price.
 
     A subtype of FitMethod.
 
     # Examples
+
+    ```julia
+    quotes = ZCBPrice([0.99, 0.97, 0.94])
+    curve = fit(Spline.Linear(), quotes, Fit.Bootstrap())
+    discount(curve, 2) ≈ 0.97 # true
+    ```
     """
     struct Bootstrap <: FitMethod
         # spline method

--- a/src/model/Yield/CairnsPritchard.jl
+++ b/src/model/Yield/CairnsPritchard.jl
@@ -2,14 +2,19 @@
     CairnsPritchard(c₁, c₂, b₀, b₁, b₂)
     CairnsPritchard(c₁=0.5, c₂=3.0) # used in fitting
 
-A Cairns-Pritchard yield curve model with 2 exponential components.
+A spot-rate curve with 2 exponential components, retained under the historical
+`CairnsPritchard` API name.
 
 The continuous zero rate at time `t` is:
 
 ``r(t) = b₀ + b₁ \\exp(-c₁ t) + b₂ \\exp(-c₂ t)``
 
-This is a generalization of Nelson-Siegel with independent decay rates per
-exponential component. Parameters and default fitting bounds:
+This implementation fits spot rates and optimizes the decay rates along with the
+coefficients. Cairns (1998), Sections 1.4 and 3, instead proposes a forward-rate
+model with four exponential components and fixed decay constants. This type does
+not reproduce that model or its parameter-stability properties.
+
+Parameters and default fitting bounds:
 
 - `c₁` decay rate for first component: `0.001 .. 10.0`
 - `c₂` decay rate for second component: `0.001 .. 10.0`
@@ -19,8 +24,8 @@ exponential component. Parameters and default fitting bounds:
 
 See also [`CairnsPritchardExtended`](@ref) for a 3-component variant.
 
-# References
-- Cairns, A.J.G. (1998). "Descriptive Bond-Yield and Forward-Rate Models for the British Government Securities Market". British Actuarial Journal, 4(2), 265-321.
+# Background reference
+- Cairns, A.J.G. (1998). "Descriptive Bond-Yield and Forward-Rate Models for the British Government Securities Market". British Actuarial Journal, 4(2), 265-321. [Author PDF](https://www.macs.hw.ac.uk/~andrewc/papers/ajgc11.pdf).
 """
 struct CairnsPritchard{T} <: AbstractYieldModel
     c₁::T
@@ -55,7 +60,12 @@ FinanceCore.discount(cp::CairnsPritchard, t) = _discount_from_zero(cp, t)
     CairnsPritchardExtended(c₁, c₂, c₃, b₀, b₁, b₂, b₃)
     CairnsPritchardExtended(c₁=0.5, c₂=2.0, c₃=5.0) # used in fitting
 
-A Cairns-Pritchard yield curve model with 3 exponential components.
+A spot-rate curve with 3 exponential components, retained under the historical
+`CairnsPritchardExtended` API name.
+
+Like [`CairnsPritchard`](@ref), this implementation optimizes decay rates and
+models spot rates. It does not implement the fixed-decay forward-rate model
+proposed by Cairns (1998).
 
 The continuous zero rate at time `t` is:
 
@@ -73,8 +83,8 @@ Parameters and default fitting bounds:
 
 See also [`CairnsPritchard`](@ref) for a 2-component variant.
 
-# References
-- Cairns, A.J.G. (1998). "Descriptive Bond-Yield and Forward-Rate Models for the British Government Securities Market". British Actuarial Journal, 4(2), 265-321.
+# Background reference
+- Cairns, A.J.G. (1998). "Descriptive Bond-Yield and Forward-Rate Models for the British Government Securities Market". British Actuarial Journal, 4(2), 265-321. [Author PDF](https://www.macs.hw.ac.uk/~andrewc/papers/ajgc11.pdf).
 """
 struct CairnsPritchardExtended{T} <: AbstractYieldModel
     c₁::T

--- a/test/CairnsPritchard.jl
+++ b/test/CairnsPritchard.jl
@@ -18,6 +18,24 @@
         @test FinanceModels.rate(FinanceModels.zero(cp, 1000.0)) ≈ 0.04 atol = 1.0e-10
     end
 
+    @testset "Fit synthetic spot-rate curves" begin
+        times = collect(0.5:0.5:20.0)
+        for (truth, initial) in (
+                (Yield.CairnsPritchard(0.5, 3.0, 0.04, -0.02, 0.01), Yield.CairnsPritchard()),
+                (Yield.CairnsPritchardExtended(0.5, 2.0, 5.0, 0.04, -0.02, 0.01, 0.005), Yield.CairnsPritchardExtended()),
+            )
+            # Generate prices independently from the documented spot-rate formula.
+            rates = [
+                truth.b₀ + truth.b₁ * exp(-truth.c₁ * t) + truth.b₂ * exp(-truth.c₂ * t) +
+                    (truth isa Yield.CairnsPritchardExtended ? truth.b₃ * exp(-truth.c₃ * t) : 0.0)
+                    for t in times
+            ]
+            prices = exp.(-rates .* times)
+            fitted = fit(initial, ZCBPrice.(prices, times))
+            @test maximum(abs.(discount.(fitted, times) .- prices)) < 5.0e-5
+        end
+    end
+
     @testset "DomainError for negative c" begin
         @test_throws DomainError Yield.CairnsPritchard(-1.0, 1.0, 0.0, 0.0, 0.0)
         @test_throws DomainError Yield.CairnsPritchard(1.0, -1.0, 0.0, 0.0, 0.0)
@@ -26,10 +44,12 @@
         @test_throws DomainError Yield.CairnsPritchardExtended(1.0, 2.0, -1.0, 0.0, 0.0, 0.0, 0.0)
     end
 
-    @testset "Fit to Cairns (1998) Figure 1 data" begin
-        # Source: Cairns (1998), Figure 1 — digitized via WebPlotDigitizer
-        # Cairns, A.J.G. (1998). "Descriptive Bond-Yield and Forward-Rate Models for
-        # the British Government Securities Market". British Actuarial Journal, 4(2), 265-321.
+    @testset "Fit to legacy digitized yield fixture" begin
+        # Previously attributed to Cairns (1998), Figure 1, via WebPlotDigitizer.
+        # Figure 1 in the author PDF illustrates optimizer jumps, not yield data:
+        # https://www.macs.hw.ac.uk/~andrewc/papers/ajgc11.pdf
+        # Provenance is unverified; retain only as a numerical regression fixture,
+        # not as validation of the published forward-rate model.
         target = [
             4.106762688183153, 4.264064261935675, 4.403887883049028, 4.550725327846389,
             4.739607977033906, 4.925342222661497, 5.017616324256814, 5.01874845567391,
@@ -49,7 +69,7 @@
         @test discount(c, 0) ≈ 1.0
 
         @testset "zero rates: $t" for (t, r) in zip(mats, target)
-            @test FinanceModels.rate(FinanceModels.zero(c, t)) ≈ r atol = 0.005
+            @test FinanceModels.rate(FinanceModels.zero(c, t)) ≈ r atol = 0.0025
         end
     end
 


### PR DESCRIPTION
Document `CairnsPritchard` and its extended variant as the spot-rate exponential models they implement, with optimized decay parameters. Preserve their API and runtime behavior while distinguishing them from Cairns (1998)'s four-component, fixed-decay forward-rate model ([author PDF](https://www.macs.hw.ac.uk/~andrewc/papers/ajgc11.pdf), Sections 1.4 and 3).

The legacy fixture's Figure 1 attribution cannot be substantiated: Figure 1 in the author PDF illustrates optimizer jumps. Retain the data as an explicitly unverified numerical regression fixture, tighten its tolerance from 50 to 25 basis points (observed maximum about 22.13 bp), and add synthetic calibration checks for both variants with a maximum absolute discount-factor error of 5e-5.

Also add a runnable Bootstrap example, describe the Option module, fix OISYield signature indentation, and ignore local `/notes/` review/planning files. Existing local notes are preserved.

Validation: all 139 CairnsPritchard checks and the Bootstrap example passed; formatted the changed test file with Runic; `git diff --check` passed. Full FinanceModels suite was not run for this documentation/test cleanup.
