### PR TITLE
Preserve the zero-rate primitive through ZeroRateCurve

### DIFF
--- a/src/model/Yield/ZeroRateCurve.jl
+++ b/src/model/Yield/ZeroRateCurve.jl
@@ -97,6 +97,13 @@ function FinanceCore.discount(zrc::ZeroRateCurve, t)
 end
 # The callable `zrc(t) ≡ discount(zrc, t)` comes from the generic `AbstractYieldModel` fallback.
 
+# Preserve the cached model's zero-rate primitive, including its limit at the
+# origin. Recovering this from discounts loses precision at tiny/long tenors.
+function Base.zero(zrc::ZeroRateCurve, t)
+    t < zero(t) && throw(DomainError(t, "ZeroRateCurve zero rate is only defined for t ≥ 0"))
+    return zero(getfield(zrc, :_model), t)
+end
+
 # Structural equality on the value-carrying fields. The `_model` field is a
 # deterministic function of (rates, tenors, spline) and may not implement `==`
 # on its underlying interpolation; ignoring it here keeps `a == b` meaningful

--- a/test/ZeroRateCurve.jl
+++ b/test/ZeroRateCurve.jl
@@ -4,6 +4,34 @@ using ForwardDiff
     rates = [0.02, 0.03, 0.035, 0.04]
     tenors = [1.0, 2.0, 5.0, 10.0]
 
+    @testset "zero-rate primitive survives the wrapper" begin
+        for spline in (
+                Spline.Linear(), Spline.Quadratic(), Spline.Cubic(),
+                Spline.PCHIP(), Spline.Akima(), Spline.MonotoneConvex(), Spline.BSpline(1),
+            )
+            flat = ZeroRateCurve(fill(0.05, 4), tenors, spline)
+            zrc = ZeroRateCurve(rates, tenors, spline)
+            model = Yield.build_model(spline, tenors, rates)
+            for t in (0.0, 1.0e-20, 0.5, 3.0, 10.0, 2.0e4)
+                @test rate(zero(flat, t)) ≈ 0.05
+                @test zero(zrc, t) == zero(model, t)
+                @test rate(zero(flat + Yield.Constant(Continuous(0.01)), t)) ≈ 0.06
+                @test rate(zero(flat + ((z, t) -> z + Continuous(0.01)), t)) ≈ 0.06
+            end
+            @test_throws DomainError zero(zrc, -1.0)
+        end
+
+        for t in (0.0, 1.0e-20, 3.0, 2.0e4)
+            wrapped(rs) = rate(zero(ZeroRateCurve(rs, tenors, Spline.Linear()), t))
+            direct(rs) = rate(zero(Yield.build_model(Spline.Linear(), tenors, rs), t))
+            @test ForwardDiff.gradient(wrapped, rates) ≈ ForwardDiff.gradient(direct, rates)
+        end
+        zrc = ZeroRateCurve(rates, tenors, Spline.Linear())
+        model = Yield.build_model(Spline.Linear(), tenors, rates)
+        @test ForwardDiff.derivative(t -> rate(zero(zrc, t)), 3.0) ≈
+            ForwardDiff.derivative(t -> rate(zero(model, t)), 3.0)
+    end
+
     @testset "MonotoneConvex (default)" begin
         zrc = ZeroRateCurve(rates, tenors)
 

--- a/test/ZeroRatePrimitive.jl
+++ b/test/ZeroRatePrimitive.jl
@@ -34,7 +34,7 @@
         ("Constant(cont)", cc), ("Constant(per)", cper),
         ("NelsonSiegel", ns), ("NSS", nss), ("CairnsPritchard", cpr),
         ("Composite(+)", comp_add), ("Composite(-)", comp_sub),
-        ("Scaled", scaled), ("TenorShift", shifted),
+        ("Scaled", scaled), ("TenorShift", shifted), ("ZeroRateCurve", zrc),
     ]
 
     @testset "discount ≡ exp(-z·t)  ($name)" for (name, c) in curves
@@ -64,6 +64,7 @@
                 ("Spline", spl), ("Constant(cont)", cc),
                 ("Constant(per)", cper), ("Composite(+)", comp_add), ("Scaled", scaled),
                 ("MonotoneConvex", mc), ("NelsonSiegel", ns), ("NSS", nss), ("CairnsPritchard", cpr),
+                ("ZeroRateCurve", zrc),
             )
             @test !isnan(FinanceCore.rate(zero(c, 0.0)))
         end


### PR DESCRIPTION
`ZeroRateCurve` caches a model with a direct zero-rate primitive, but currently recovers its own zero rates from discount factors. A flat 5% linear curve consequently returns NaN at zero, -0.0 at 1e-20, and Inf at 20000.

Delegate `zero` to the cached model while retaining the wrapper's rejection of negative times. This also preserves the primitive for shifts and curve composition, without an exponential/logarithm round trip.

Validation:
- Wrapper equivalence across seven interpolants, the origin, tiny and long tenors, shifts, composites, and ForwardDiff.
- Full package suite passes on Julia 1.12.5 (3,599 assertions), including Aqua, ActuaryUtilities integration, and both plotting extensions.
- Focused ZeroRateCurve and zero-rate primitive suites pass on Julia 1.10.10 and 1.12.5 (568 assertions each).
- Runic formatting and `git diff --check` pass.

Independent change against `master`; does not depend on the open curve-storage/extrapolation stack.
