### PR TITLE
Own contract projection model requirements in FinanceModels

### DIFF
--- a/docs/src/contracts.md
+++ b/docs/src/contracts.md
@@ -146,6 +146,27 @@ end
 
 ##### Cashflows are model dependent
 
+FinanceModels owns the model requirements of projectable contracts. Use
+`model_requirements(contract)` to inspect the `key => model_type` pairs, including
+those inside composites, forward-starting contracts, transformed legs, portfolios,
+and FX wrappers. Custom projectable contracts extend this function; an unknown
+contract is never assumed to be model independent.
+
+For a shared index curve, `Projection(contract; index=curve)` wires the required
+keys automatically. Rebuild this projection inside a valuation closure to recompute
+floating coupons when the index curve changes:
+
+```julia
+curve = Yield.Constant(0.04)
+swap = InterestRateSwap(curve, 5.0)
+value(index, credit) = present_value(credit, Projection(swap; index))
+value(curve, curve) # approximately zero
+```
+
+For multiple index curves or combined yield and FX requirements, use an explicit
+store, for example `Projection(contract, Dict("SOFR" => sofr, "EURUSD" => fx))`.
+The single-model convenience form rejects a model of the wrong required type.
+
 An example of this is a floating bond where the coupon paid depends on a view of forward rates. See [this section in the overview](@ref Contracts-that-depend-on-the-model-(or-multiple-models)) on projections for how this is handled.
 
 ## Available Contracts & Modules

--- a/docs/src/contracts.md
+++ b/docs/src/contracts.md
@@ -147,10 +147,16 @@ end
 ##### Cashflows are model dependent
 
 FinanceModels owns the model requirements of projectable contracts. Use
-`model_requirements(contract)` to inspect the `key => model_type` pairs, including
+`model_requirements(contract)` to iterate over the `key => model_type` pairs, including
 those inside composites, forward-starting contracts, transformed legs, portfolios,
 and FX wrappers. Custom projectable contracts extend this function; an unknown
 contract is never assumed to be model independent.
+
+The protocol returns an iterable: small fixed contracts may return tuples, while
+runtime portfolios are flattened lazily, including inside contract wrappers.
+Use `collect(model_requirements(contract))` when a materialized list is needed.
+The convenience constructor consumes requirements once and validates every
+occurrence, even when a repeated key has different model type constraints.
 
 For a shared index curve, `Projection(contract; index=curve)` wires the required
 keys automatically. Rebuild this projection inside a valuation closure to recompute

--- a/docs/src/contracts.md
+++ b/docs/src/contracts.md
@@ -49,6 +49,9 @@ struct PrincipleOnlyBond{F<:FinanceCore.Frequency} <: FinanceModels.Bond.Abstrac
     maturity::Float64
 end
 
+# This contract needs no model when using Projection(contract; index).
+FinanceModels.model_requirements(::PrincipleOnlyBond) = ()
+
 # We extend the interface to say what should happen as the bond is projected
 # There's two parts to customize:
 # 1. any initialization or state to keep track of
@@ -154,6 +157,8 @@ contract is never assumed to be model independent.
 
 The protocol returns an iterable: small fixed contracts may return tuples, while
 runtime portfolios are flattened lazily, including inside contract wrappers.
+Use arrays for large portfolios to avoid compilation costs from deeply nested
+`Composite` types.
 Use `collect(model_requirements(contract))` when a materialized list is needed.
 The convenience constructor consumes requirements once and validates every
 occurrence, even when a repeated key has different model type constraints.
@@ -172,6 +177,9 @@ value(curve, curve) # approximately zero
 For multiple index curves or combined yield and FX requirements, use an explicit
 store, for example `Projection(contract, Dict("SOFR" => sofr, "EURUSD" => fx))`.
 The single-model convenience form rejects a model of the wrong required type.
+Its generated store is a `Dict{Any, typeof(index)}`, supporting mixed key types
+while retaining concrete model values. Pass an explicit store when downstream
+code requires a particular store or key type.
 
 An example of this is a floating bond where the coupon paid depends on a view of forward rates. See [this section in the overview](@ref Contracts-that-depend-on-the-model-(or-multiple-models)) on projections for how this is handled.
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -53,6 +53,9 @@ struct PrincipalOnlyBond{F<:FinanceCore.Frequency} <: FinanceModels.Bond.Abstrac
     maturity::Float64
 end
 
+# This contract needs no model when using Projection(contract; index).
+FinanceModels.model_requirements(::PrincipalOnlyBond) = ()
+
 # We extend the interface to say what should happen as the bond is projected
 # There's two parts to customize:
 # 1. any initialization or state to keep track of
@@ -72,7 +75,11 @@ function Transducers.__foldl__(rf, val, p::Projection{C,M,K}) where {C<:Principa
 end
 ```
 
-That's it! then we can use this contract to fitting models, create projections, quotes, etc. Here we simply collect the bond into an array of cashflows:
+Custom contracts declare [`model_requirements`](@ref) to support
+`Projection(contract; index)`: return `()` when no model is needed, or an iterable
+of `key => model_type` pairs for model-dependent cashflows.
+
+We can now use this contract to fit models, create projections, quotes, etc. Here we simply collect the bond into an array of cashflows:
 
 ```julia-repl
 julia> PrincipalOnlyBond(Periodic(2),5.) |> collect

--- a/src/FinanceModels.jl
+++ b/src/FinanceModels.jl
@@ -22,6 +22,7 @@ include("utils.jl")
 include("Contract.jl")
 include("model/Model.jl")
 include("Projection.jl")
+include("projection_models.jl")
 include("fit.jl")
 
 export Cashflow, Quote, Forward, CommonEquity, Option, InterestRateSwap
@@ -42,7 +43,7 @@ export par
 export Equity, Volatility
 export FX
 export ShortRate, AbstractStochasticModel, RatePath, simulate, pv_mc, short_rate
-export Projection, CashflowProjection
+export Projection, CashflowProjection, model_requirements
 export pv
 export Fit, fit
 

--- a/src/Projection.jl
+++ b/src/Projection.jl
@@ -6,6 +6,9 @@ abstract type AbstractProjection end
 The set of `contract`s and assumptions (`model`) to project the `kind` of output desired. Some assets require a projection in order to be valued (e.g. a floating rate bond).
 
 If attempting to `collect` or otherwise reduce a contract (`<:AbstractContract`), by default it will get wrapped into a `Projection(contract,NullModel(),CashflowProjection())`
+
+Use `Projection(contract; index)` to build a shared-index model store from
+[`model_requirements`](@ref).
 """
 struct Projection{C, M, K} <: AbstractProjection
     contract::C

--- a/src/Projection.jl
+++ b/src/Projection.jl
@@ -65,7 +65,7 @@ Base.collect(c::C) where {C <: FinanceCore.AbstractContract} = Projection(c) |> 
 
 # the default projection is just one where we get the cashflows and assume that the contract needs
 # no assumptions/model to determine the cashflows (the contract will error if a certain model is needed)
-Projection(c) = Projection(c, NullModel(), CashflowProjection())
+# The default and keyword index forms are defined in projection_models.jl.
 # if the model is also given, assume that we want a `CashflowProjection` by default
 Projection(c, m) = Projection(c, m, CashflowProjection())
 

--- a/src/projection_models.jl
+++ b/src/projection_models.jl
@@ -1,0 +1,59 @@
+"""
+    model_requirements(contract) -> Tuple
+
+Return the `key => model_type` requirements for a cashflow projection. Fixed
+cashflows have no requirements; floating bonds require a yield model, and
+`FX.Converted` wrappers require an FX model as well as their inner requirements.
+Composites, forwards, portfolios, and Transducers eductions retain the requirements
+of their underlying contracts. A key may occur more than once: its model must
+satisfy every occurrence.
+
+Custom projectable contracts should implement this function, returning `()` only
+when they require no model. There is no model-independent fallback for unknown
+contracts. Explicit `Projection(contract, model_store)` remains available without
+implementing this convenience protocol.
+"""
+function model_requirements end
+
+model_requirements(::Cashflow) = ()
+model_requirements(::Bond.Fixed) = ()
+model_requirements(::FX.BasisSwapLeg) = ()
+model_requirements(c::Bond.Floating) = (c.key => Yield.AbstractYieldModel,)
+model_requirements(c::FinanceCore.Composite) = (model_requirements(c.a)..., model_requirements(c.b)...)
+model_requirements(c::Forward) = model_requirements(c.instrument)
+model_requirements(c::Transducers.Eduction) = model_requirements(c.coll)
+model_requirements(c::FX.Converted) = (c.key => FX.AbstractFXModel, model_requirements(c.contract)...)
+model_requirements(cs::AbstractArray) = Tuple(req for c in cs for req in model_requirements(c))
+
+"""
+    Projection(contract; index)
+
+Project a contract or portfolio using `index` for every required model key.
+The model must satisfy all [`model_requirements`](@ref). For contracts with
+different index curves or an FX conversion, pass an explicit model store instead:
+`Projection(contract, Dict("SOFR" => sofr, "EURUSD" => fx))`.
+
+This form is useful inside a valuation closure: rebuilding the projection with a
+bumped `index` recomputes floating coupons, including transformed swap legs.
+Omitting `index` retains the default model-free projection.
+
+```julia
+curve = Yield.Constant(0.04)
+swap = InterestRateSwap(curve, 5.0)
+value(index, discount_curve) = present_value(discount_curve, Projection(swap; index))
+value(curve, curve) # approximately zero
+```
+"""
+function Projection(c; index = nothing)
+    isnothing(index) && return Projection(c, NullModel(), CashflowProjection())
+    requirements = model_requirements(c)
+    for (key, model_type) in requirements
+        index isa model_type || throw(
+            ArgumentError(
+                "Projection: key $(repr(key)) requires $model_type, but index is $(typeof(index)). " *
+                    "Pass an explicit model store with Projection(contract, models)."
+            )
+        )
+    end
+    return Projection(c, Dict(key => index for (key, _) in requirements), CashflowProjection())
+end

--- a/src/projection_models.jl
+++ b/src/projection_models.jl
@@ -1,17 +1,19 @@
 """
-    model_requirements(contract) -> Tuple
+    model_requirements(contract) -> iterable
 
 Return the `key => model_type` requirements for a cashflow projection. Fixed
 cashflows have no requirements; floating bonds require a yield model, and
 `FX.Converted` wrappers require an FX model as well as their inner requirements.
 Composites, forwards, portfolios, and Transducers eductions retain the requirements
-of their underlying contracts. A key may occur more than once: its model must
-satisfy every occurrence.
+of their underlying contracts. Runtime portfolios are traversed lazily; small,
+fixed contract requirements may be tuples. A key may occur more than once: its
+model must satisfy every occurrence.
 
-Custom projectable contracts should implement this function, returning `()` only
-when they require no model. There is no model-independent fallback for unknown
-contracts. Explicit `Projection(contract, model_store)` remains available without
-implementing this convenience protocol.
+Custom projectable contracts should implement this function, returning an iterable
+of pairs (empty, for example `()`, only when they require no model). The convenience
+constructor consumes the requirements once. There is no model-independent fallback
+for unknown contracts. Explicit `Projection(contract, model_store)` remains available
+without implementing this convenience protocol.
 """
 function model_requirements end
 
@@ -19,11 +21,19 @@ model_requirements(::Cashflow) = ()
 model_requirements(::Bond.Fixed) = ()
 model_requirements(::FX.BasisSwapLeg) = ()
 model_requirements(c::Bond.Floating) = (c.key => Yield.AbstractYieldModel,)
-model_requirements(c::FinanceCore.Composite) = (model_requirements(c.a)..., model_requirements(c.b)...)
+model_requirements(c::FinanceCore.Composite) = _combine_model_requirements(model_requirements(c.a), model_requirements(c.b))
 model_requirements(c::Forward) = model_requirements(c.instrument)
 model_requirements(c::Transducers.Eduction) = model_requirements(c.coll)
-model_requirements(c::FX.Converted) = (c.key => FX.AbstractFXModel, model_requirements(c.contract)...)
-model_requirements(cs::AbstractArray) = Tuple(req for c in cs for req in model_requirements(c))
+model_requirements(c::FX.Converted) = _combine_model_requirements((c.key => FX.AbstractFXModel,), model_requirements(c.contract))
+model_requirements(cs::AbstractArray) = Iterators.flatten(model_requirements(c) for c in cs)
+
+# Preserve fixed contract tuples without materializing runtime portfolio iterators.
+_combine_model_requirements(a::Tuple, b::Tuple) = (a..., b...)
+function _combine_model_requirements(a, b)
+    a === () && return b
+    b === () && return a
+    return Iterators.flatten((a, b))
+end
 
 """
     Projection(contract; index)
@@ -46,14 +56,17 @@ value(curve, curve) # approximately zero
 """
 function Projection(c; index = nothing)
     isnothing(index) && return Projection(c, NullModel(), CashflowProjection())
-    requirements = model_requirements(c)
-    for (key, model_type) in requirements
+    # Fold the lazy requirement tree directly. Keys may be heterogeneous, but
+    # every stored value is the supplied index model.
+    models = foldl(model_requirements(c); init = Dict{Any, typeof(index)}()) do models, (key, model_type)
         index isa model_type || throw(
             ArgumentError(
                 "Projection: key $(repr(key)) requires $model_type, but index is $(typeof(index)). " *
                     "Pass an explicit model store with Projection(contract, models)."
             )
         )
+        models[key] = index
+        models
     end
-    return Projection(c, Dict(key => index for (key, _) in requirements), CashflowProjection())
+    return Projection(c, models, CashflowProjection())
 end

--- a/src/projection_models.jl
+++ b/src/projection_models.jl
@@ -8,14 +8,29 @@ Composites, forwards, portfolios, and Transducers eductions retain the requireme
 of their underlying contracts. Runtime portfolios are traversed lazily; small,
 fixed contract requirements may be tuples. A key may occur more than once: its
 model must satisfy every occurrence.
+Use arrays for large portfolios to avoid compilation costs from deeply nested
+`Composite` types.
 
 Custom projectable contracts should implement this function, returning an iterable
 of pairs (empty, for example `()`, only when they require no model). The convenience
 constructor consumes the requirements once. There is no model-independent fallback
-for unknown contracts. Explicit `Projection(contract, model_store)` remains available
-without implementing this convenience protocol.
+for unknown contracts: an undeclared `AbstractContract` raises an `ArgumentError`
+that explains how to declare its requirements. Explicit
+`Projection(contract, model_store)` remains available without implementing this
+convenience protocol.
 """
 function model_requirements end
+
+function model_requirements(c::FinanceCore.AbstractContract)
+    throw(
+        ArgumentError(
+            "$(typeof(c)) does not declare its projection model requirements. " *
+                "Define FinanceModels.model_requirements for this contract " *
+                "(returning () if no model is needed), or pass an explicit model store " *
+                "with Projection(contract, models)."
+        )
+    )
+end
 
 model_requirements(::Cashflow) = ()
 model_requirements(::Bond.Fixed) = ()
@@ -42,6 +57,10 @@ Project a contract or portfolio using `index` for every required model key.
 The model must satisfy all [`model_requirements`](@ref). For contracts with
 different index curves or an FX conversion, pass an explicit model store instead:
 `Projection(contract, Dict("SOFR" => sofr, "EURUSD" => fx))`.
+
+The generated store is a `Dict{Any, typeof(index)}`: keys may have mixed types,
+while model values keep the concrete type of `index`. Pass an explicit store if
+downstream code requires a particular store or key type.
 
 This form is useful inside a valuation closure: rebuilding the projection with a
 bumped `index` recomputes floating coupons, including transformed swap legs.

--- a/test/projection_models.jl
+++ b/test/projection_models.jl
@@ -1,0 +1,67 @@
+using ForwardDiff
+
+struct UndeclaredProjectionContract <: FinanceCore.AbstractContract end
+struct DeclaredProjectionContract <: FinanceCore.AbstractContract
+    key::Symbol
+end
+FinanceModels.model_requirements(c::DeclaredProjectionContract) = (c.key => Yield.AbstractYieldModel,)
+
+@testset "Projection model requirements" begin
+    curve = Yield.Constant(Continuous(0.04))
+    credit = Yield.Constant(Continuous(0.06))
+    fixed = Bond.Fixed(0.05, Periodic(2), 5.0)
+    floating = Bond.Floating(0.001, Periodic(4), 5.0, :index)
+    swap = InterestRateSwap(curve, 5.0; model_key = :index)
+    transformed = floating |> Map(-) |> Map(cf -> cf * 2)
+    forward_start = Forward(1.0, floating)
+    portfolio = [swap, fixed, forward_start]
+    store = Dict(:index => curve)
+
+    @test model_requirements(fixed) == ()
+    @test model_requirements(Cashflow(1.0, 2.0)) == ()
+    for c in (floating, swap, transformed, forward_start)
+        @test model_requirements(c) == (:index => Yield.AbstractYieldModel,)
+        @test collect(Projection(c; index = curve)) == collect(Projection(c, store))
+        @test present_value(credit, Projection(c; index = curve)) ≈
+            present_value(credit, Projection(c, store))
+        auto(r) = present_value(credit, Projection(c; index = Yield.Constant(Continuous(r))))
+        explicit(r) = present_value(credit, Projection(c, Dict(:index => Yield.Constant(Continuous(r)))))
+        @test ForwardDiff.derivative(auto, 0.04) ≈ ForwardDiff.derivative(explicit, 0.04)
+    end
+    @test present_value(curve, Projection(swap; index = curve)) ≈ 0.0 atol = 1.0e-12
+    @test model_requirements(portfolio) == (:index => Yield.AbstractYieldModel, :index => Yield.AbstractYieldModel)
+    @test present_value(credit, Projection(portfolio; index = curve)) ≈
+        sum(present_value(credit, Projection(c, store)) for c in portfolio)
+    @test isempty(model_requirements(FinanceCore.AbstractContract[]))
+    @test isempty(Projection(FinanceCore.AbstractContract[]; index = curve).model)
+    @test Projection(fixed).model isa NullModel
+    @test collect(Projection(fixed; index = curve)) == collect(fixed)
+
+    # Distinct index keys may share a curve, but remain explicit in the protocol.
+    other = Bond.Floating(0.0, Periodic(2), 3.0, "other")
+    both = FinanceCore.Composite(floating, other)
+    @test model_requirements(both) == (:index => Yield.AbstractYieldModel, "other" => Yield.AbstractYieldModel)
+    @test collect(Projection(both; index = curve)) ==
+        collect(Projection(both, Dict(:index => curve, "other" => curve)))
+
+    pair = FX.Pair(:EUR, :USD)
+    fx = FX.Forwards(pair, 1.08, credit, curve)
+    converted = FX.Converted(transformed, pair, :fx)
+    @test model_requirements(converted) == (:fx => FX.AbstractFXModel, :index => Yield.AbstractYieldModel)
+    @test_throws "explicit model store" Projection(converted; index = curve)
+    @test_throws "explicit model store" Projection(converted; index = fx)
+    @test_throws "explicit model store" Projection(floating; index = fx)
+    explicit_fx = Projection(converted, Dict(:fx => fx, :index => curve))
+    @test present_value(credit, explicit_fx) ≈ 1.08 * present_value(curve, Projection(transformed, store))
+    fixed_fx = FX.Converted(fixed, pair, :fx)
+    @test collect(Projection(fixed_fx; index = fx)) == collect(Projection(fixed_fx, Dict(:fx => fx)))
+    @test model_requirements(FX.BasisSwapLeg(pair, [Cashflow(1.0, 2.0)])) == ()
+
+    # An extension must declare its needs; explicit stores keep working without
+    # adopting the convenience protocol, and are not replaced by inferred wiring.
+    unknown = UndeclaredProjectionContract()
+    @test_throws MethodError model_requirements(unknown)
+    @test_throws MethodError Projection(unknown; index = curve)
+    @test Projection(unknown, store).model === store
+    @test Projection(DeclaredProjectionContract(:custom); index = curve).model[:custom] === curve
+end

--- a/test/projection_models.jl
+++ b/test/projection_models.jl
@@ -1,4 +1,6 @@
-using ForwardDiff
+module ProjectionModelTests
+
+using Test, FinanceCore, FinanceModels, Transducers, ForwardDiff
 
 struct UndeclaredProjectionContract <: FinanceCore.AbstractContract end
 struct DeclaredProjectionContract <: FinanceCore.AbstractContract
@@ -65,8 +67,8 @@ FinanceModels.model_requirements(c::IterableProjectionContract) = c.requirements
     # An extension must declare its needs; explicit stores keep working without
     # adopting the convenience protocol, and are not replaced by inferred wiring.
     unknown = UndeclaredProjectionContract()
-    @test_throws MethodError model_requirements(unknown)
-    @test_throws MethodError Projection(unknown; index = curve)
+    @test_throws ArgumentError model_requirements(unknown)
+    @test_throws r"UndeclaredProjectionContract.*Define FinanceModels.model_requirements.*returning \(\).*explicit model store" Projection(unknown; index = curve)
     @test Projection(unknown, store).model === store
     @test Projection(DeclaredProjectionContract(:custom); index = curve).model[:custom] === curve
 
@@ -101,7 +103,7 @@ FinanceModels.model_requirements(c::IterableProjectionContract) = c.requirements
             cs = FinanceCore.AbstractContract[floating, unknown]
             requirements = model_requirements(wrap(cs))
             @test first(requirements) in (:index => Yield.AbstractYieldModel, :fx => FX.AbstractFXModel)
-            @test_throws MethodError collect(requirements)
+            @test_throws ArgumentError collect(requirements)
         end
     end
 
@@ -134,3 +136,5 @@ FinanceModels.model_requirements(c::IterableProjectionContract) = c.requirements
         @test_throws "key :index requires $(Yield.AbstractYieldModel)" Projection(FX.Converted(floating, pair, :index); index = fx)
     end
 end
+
+end # module ProjectionModelTests

--- a/test/projection_models.jl
+++ b/test/projection_models.jl
@@ -6,6 +6,11 @@ struct DeclaredProjectionContract <: FinanceCore.AbstractContract
 end
 FinanceModels.model_requirements(c::DeclaredProjectionContract) = (c.key => Yield.AbstractYieldModel,)
 
+struct IterableProjectionContract{R} <: FinanceCore.AbstractContract
+    requirements::R
+end
+FinanceModels.model_requirements(c::IterableProjectionContract) = c.requirements
+
 @testset "Projection model requirements" begin
     curve = Yield.Constant(Continuous(0.04))
     credit = Yield.Constant(Continuous(0.06))
@@ -29,7 +34,7 @@ FinanceModels.model_requirements(c::DeclaredProjectionContract) = (c.key => Yiel
         @test ForwardDiff.derivative(auto, 0.04) ≈ ForwardDiff.derivative(explicit, 0.04)
     end
     @test present_value(curve, Projection(swap; index = curve)) ≈ 0.0 atol = 1.0e-12
-    @test model_requirements(portfolio) == (:index => Yield.AbstractYieldModel, :index => Yield.AbstractYieldModel)
+    @test collect(model_requirements(portfolio)) == [:index => Yield.AbstractYieldModel, :index => Yield.AbstractYieldModel]
     @test present_value(credit, Projection(portfolio; index = curve)) ≈
         sum(present_value(credit, Projection(c, store)) for c in portfolio)
     @test isempty(model_requirements(FinanceCore.AbstractContract[]))
@@ -64,4 +69,68 @@ FinanceModels.model_requirements(c::DeclaredProjectionContract) = (c.key => Yiel
     @test_throws MethodError Projection(unknown; index = curve)
     @test Projection(unknown, store).model === store
     @test Projection(DeclaredProjectionContract(:custom); index = curve).model[:custom] === curve
+
+    @testset "Runtime portfolios stay lazy through wrappers" begin
+        small = fill(floating, 1)
+        large = fill(floating, 10_000)
+        yield_requirement = :index => Yield.AbstractYieldModel
+        fx_requirement = :fx => FX.AbstractFXModel
+        for (wrap, expected) in (
+                (identity, (yield_requirement,)),
+                (cs -> FinanceCore.Composite(fixed, cs), (yield_requirement,)),
+                (cs -> FinanceCore.Composite(cs, floating), (yield_requirement, yield_requirement)),
+                (cs -> Forward(1.0, FinanceCore.Composite(fixed, cs)), (yield_requirement,)),
+                (cs -> cs |> Map(-), (yield_requirement,)),
+                (cs -> FX.Converted(cs, pair, :fx), (fx_requirement, yield_requirement)),
+                (cs -> FinanceCore.Composite(FX.Converted(cs, pair, :fx), cs), (fx_requirement, yield_requirement, yield_requirement)),
+            )
+            small_requirements = @inferred model_requirements(wrap(small))
+            large_requirements = @inferred model_requirements(wrap(large))
+            @test !(large_requirements isa Tuple)
+            @test typeof(small_requirements) === typeof(large_requirements)
+            @test Tuple(small_requirements) == expected
+        end
+        @test count(==(:index => Yield.AbstractYieldModel), model_requirements(large)) == length(large)
+        @test Projection(large; index = curve).model == store
+        @test collect(model_requirements(reshape(large, 100, 100))) == collect(model_requirements(large))
+        nested = [Bond.Floating[], small, Bond.Floating[], small]
+        @test collect(model_requirements(nested)) == fill(:index => Yield.AbstractYieldModel, 2)
+
+        # Obtaining requirements must not visit array elements, even through wrappers.
+        for wrap in (identity, cs -> FinanceCore.Composite(fixed, cs), cs -> FX.Converted(cs, pair, :fx))
+            cs = FinanceCore.AbstractContract[floating, unknown]
+            requirements = model_requirements(wrap(cs))
+            @test first(requirements) in (:index => Yield.AbstractYieldModel, :fx => FX.AbstractFXModel)
+            @test_throws MethodError collect(requirements)
+        end
+    end
+
+    @testset "Every occurrence is validated in one pass" begin
+        requirements = Iterators.Stateful(
+            [
+                :index => Yield.AbstractYieldModel,
+                :index => typeof(curve),
+                :other => Yield.AbstractYieldModel,
+            ]
+        )
+        custom = IterableProjectionContract(requirements)
+        @test Projection(custom; index = curve).model == Dict(:index => curve, :other => curve)
+        @test isempty(requirements)
+
+        # Repeated keys may impose incompatible constraints, in either order.
+        for types in ((Yield.AbstractYieldModel, FX.AbstractFXModel), (FX.AbstractFXModel, Yield.AbstractYieldModel))
+            for index in (curve, fx)
+                requirements = Iterators.Stateful([:index => types[1], :index => types[2]])
+                custom = IterableProjectionContract(requirements)
+                invalid_type = index isa types[1] ? types[2] : types[1]
+                @test_throws "key :index requires $invalid_type" Projection(custom; index)
+            end
+        end
+        conflict = FX.Converted(fixed, pair, :index)
+        cs = FinanceCore.AbstractContract[fill(floating, 1_000); conflict]
+        for wrap in (identity, cs -> FinanceCore.Composite(fixed, cs), cs -> Forward(1.0, FinanceCore.Composite(fixed, cs)), cs -> cs |> Map(-))
+            @test_throws "key :index requires $(FX.AbstractFXModel)" Projection(wrap(cs); index = curve)
+        end
+        @test_throws "key :index requires $(Yield.AbstractYieldModel)" Projection(FX.Converted(floating, pair, :index); index = fx)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using Test
 using Transducers
 
 include("generic.jl")
+include("projection_models.jl")
 include("sp.jl")
 
 include("Equity.jl")


### PR DESCRIPTION
ActuaryUtilities currently reconstructs FinanceModels' contract tree to discover projection model keys. Its traversal misses the transformed floating leg in `InterestRateSwap`, causing contract reprojection and sensitivities to fail.

Add the FM-owned `model_requirements(contract)` protocol and `Projection(contract; index)` convenience constructor. Requirements are an iterable of keys and expected model types, covering composites, forwards, arrays, transformed legs, and FX wrappers. Runtime portfolios flatten lazily through wrappers, so their return type does not contain a tuple whose length depends on portfolio size. Small fixed contract requirements remain tuples.

The convenience constructor folds requirements once and validates every occurrence before inserting its key, including conflicting constraints on repeated keys. This also supports iterators that can be consumed only once. Explicit stores continue to handle distinct index curves and mixed yield/FX requirements. Unknown contracts must declare requirements before using the convenience form; an actionable `ArgumentError` names the missing method and the explicit-store alternative. The custom-contract tutorials show the declaration, and the API documents the intentionally `Any`-keyed store and array guidance for large portfolios.

This provides the FinanceModels side of the shared AU/FM review finding. ActuaryUtilities can replace its private `_contract_keys` traversal and duplicated store construction with `Projection(contract; index)` in a consumer change; this PR does not modify AU.

Validation:

- 80 focused assertions pass on Julia 1.10.10 and 1.12.5, including cashflows, prices, AD derivatives, seven wrapper forms around 10,000-contract portfolios, nested/multidimensional/empty arrays, single-pass iterators, and repeated-key conflicts in both orders with both candidate models.
- Full package suite passes on Julia 1.12.5: 3,475 assertions, including Aqua, ActuaryUtilities integration, and both plotting extensions.
- Documentation build and both custom-contract tutorial examples pass (six assertions). Test-only contract types are scoped to a dedicated module.
- Runic formatting and `git diff --check` pass.

Allocation and warmed latency comparison against reviewed commit `9c5652e`, Julia 1.12.5 on Apple M4; one shared index key, inputs created outside timing, median of nine batches:

| Projection construction | Before bytes | After bytes | Before µs | After µs |
|---|---:|---:|---:|---:|
| Array of 1,000 floaters | 153,664 | 480 | 331.540 | 4.391 |
| Array of 10,000 floaters | 1,447,104 | 480 | 482.300 | 49.571 |
| Floating leg + array of 10,000 floaters | 2,007,520 | 528 | 811.683 | 49.296 |
| AbstractContract array: fixed leg + 10,000 floaters | 6,239,120 | 160,496 | 4,068.438 | 133.975 |

Escaped array requirement construction uses 16 bytes independent of portfolio length. Single floating bonds and swaps retain their allocation counts. Abstractly typed portfolios still incur per-contract dispatch allocations; storage also grows with distinct model keys.
